### PR TITLE
Setup automated Travis-CI Linux Deployments(#290)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo apt-get update -qq
 
 install:
-  - sudo apt-get install -qq libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-net1.2-dev
+  - sudo apt-get install -qq libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-net1.2-dev rpm
   - if [ "$CC" = "gcc" ]; then sudo apt-get install -qq gcc-4.8; fi
 
 before_script:
@@ -24,3 +24,18 @@ script:
   - cmake .
   - make -j2
   - make test
+before_deploy:
+  - "cd ./src && sudo make package"
+  - "sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*"
+deploy:
+  provider: releases
+  api_key:
+    secure: cJSUi9wKAjJ7LqPQ8UXnMfHoDYwow4lHqQnp+EGAle1BHrbwMYPinfQzzLXRy40rqFrF2b/t0qBsGNJRNGBhI65nSgJElLGsgyAkV3h31uvVop5T4f93eEcuFMPYG74UtUPwTPTmRLB1GxZumELvKgJyne7xF4JHTvUDlsQAqg0=
+  file:
+    - "$TRAVIS_BUILD_DIR/C-Dogs SDL-$TRAVIS_TAG-Linux.deb"
+    - "$TRAVIS_BUILD_DIR/C-Dogs SDL-$TRAVIS_TAG-Linux.tar.gz"
+    - "$TRAVIS_BUILD_DIR/C-Dogs-SDL-$TRAVIS_TAG-Linux.rpm"
+  skip_cleanup: true
+  on:
+    tags: true
+    condition: $CC = gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_deploy:
 deploy:
   provider: releases
   api_key:
-    secure: cJSUi9wKAjJ7LqPQ8UXnMfHoDYwow4lHqQnp+EGAle1BHrbwMYPinfQzzLXRy40rqFrF2b/t0qBsGNJRNGBhI65nSgJElLGsgyAkV3h31uvVop5T4f93eEcuFMPYG74UtUPwTPTmRLB1GxZumELvKgJyne7xF4JHTvUDlsQAqg0=
+    secure: 59BXlwvCT1GMuMrx5yf9TjD6BsXbxxC/lAB7ry7sFMdKmNg8v9vs9lH8g31XF2BPPDaH1 sepJjRhn0qHciikQJ3X+ZbN2YpFF6KNKp/FOw3ytx/8SDiWO2BzqVnstE+XihRdki+oR2ntPFKhEMhWs RlS2o9JY+g9pT+0BLtqp4I=
   file:
     - "$TRAVIS_BUILD_DIR/C-Dogs SDL-$TRAVIS_TAG-Linux.deb"
     - "$TRAVIS_BUILD_DIR/C-Dogs SDL-$TRAVIS_TAG-Linux.tar.gz"


### PR DESCRIPTION
Add `rpm` package to `apt-get install` line in .travis.yml under the
`install` option.

Modify .travis.yml to include `before_deploy` & `deploy` options.

From this point all that needs to be done, is to generate an 
[Access Token](https://help.github.com/articles/creating-an-access-token-for-command-line-use/), and [encrypt](http://docs.travis-ci.com/user/encryption-keys/) it via `travis encrypt "AccessToken"` and replacing `cJSUi9wKAjJ7LqPQ8UXnMfHoDYwow4lHqQnp+EGAle1BHrbwMYPinfQzzLXRy40rqFrF2b/t0qBsGNJRNGBhI65nSgJElLGsgyAkV3h31uvVop5T4f93eEcuFMPYG74UtUPwTPTmRLB1GxZumELvKgJyne7xF4JHTvUDlsQAqg0=`
in .travis.yml with the encrypted token echo'd out. 

Feel free to post an encrypted Access Token and I will revise my commits to include it instead.

If there is anything that isn't pragmatic or is out of place, feel free to let me know below and I will make corrections.