### PR TITLE
Remove .deb & .rpm packages from Travis Releases temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,7 @@ deploy:
     secure: Rus8lTl0EnVqM6PXwleQ8cffjMTMY1gHGwVdbGsu8cWaDgAWQ86TFgGBbV+x12z9floDPzI7Z1K/entktkiSWQyRPIa9jQfJBIomNABhIykUvpRsL026Cs8TysI4L4hrTvFev10QI28RFyZvUDBT8yytowFsuU5Pfb4n7kDIisQ=
   file_glob: true
   file:
-    - "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.deb"
     - "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.tar.gz"
-    - "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.rpm"
   skip_cleanup: true
   on:
     tags: true


### PR DESCRIPTION
Removed .deb, and .rpm packages from Travis Deployments due to failures addressed in #345. This is temporary assuming the issues are addressed in #89 & #224, or targeted distributions are changed.