### PR TITLE
Enhancement/peripheral hud

### DIFF
--- a/src/cdogs/actors.c
+++ b/src/cdogs/actors.c
@@ -1156,6 +1156,7 @@ TActor *ActorAdd(NActorAdd aa)
 	}
 	actor->gunIndex = 0;
 	actor->health = aa.Health;
+	actor->lastHealth = actor->health;
 	actor->action = ACTORACTION_MOVING;
 	actor->tileItem.x = actor->tileItem.y = -1;
 	actor->tileItem.kind = KIND_CHARACTER;

--- a/src/cdogs/actors.c
+++ b/src/cdogs/actors.c
@@ -115,6 +115,11 @@ void UpdateActorState(TActor * actor, int ticks)
 
 	if (actor->health > 0)
 	{
+		if (actor->lastHealth != actor->health)
+		{
+			actor->lastHealth > actor->health ? -- actor->lastHealth:
+				++ actor->lastHealth;
+		}
 		actor->flamed = MAX(0, actor->flamed - ticks);
 		if (actor->poisoned)
 		{
@@ -499,6 +504,7 @@ static void CheckRescue(const TActor *a)
 
 void ActorHeal(TActor *actor, int health)
 {
+	actor->lastHealth = actor->health;
 	actor->health += health;
 	actor->health = MIN(actor->health, ActorGetCharacter(actor)->maxHealth);
 }
@@ -506,6 +512,7 @@ void ActorHeal(TActor *actor, int health)
 void InjureActor(TActor * actor, int injury)
 {
 	const int lastHealth = actor->health;
+	actor->lastHealth = actor->health;
 	actor->health -= injury;
 	if (lastHealth > 0 && actor->health <= 0)
 	{

--- a/src/cdogs/actors.c
+++ b/src/cdogs/actors.c
@@ -512,7 +512,6 @@ void ActorHeal(TActor *actor, int health)
 void InjureActor(TActor * actor, int injury)
 {
 	const int lastHealth = actor->health;
-	actor->lastHealth = actor->health;
 	actor->health -= injury;
 	if (lastHealth > 0 && actor->health <= 0)
 	{

--- a/src/cdogs/actors.h
+++ b/src/cdogs/actors.h
@@ -126,6 +126,7 @@ typedef struct Actor
 	int gunIndex;
 
 	int health;
+	int lastHealth;
 	// A counter for player death
 	// If 0, player is alive
 	// If >0 but less than DEATH_MAX, player is "dying" and this variable

--- a/src/cdogs/hud.c
+++ b/src/cdogs/hud.c
@@ -737,6 +737,7 @@ static void DrawObjectiveCompass(
 	}
 }
 
+#define COMP_SATURATE_DIST 350
 static void DrawCompassArrow(
 	GraphicsDevice *g, Rect2i r, Vec2i pos, Vec2i playerPos, color_t mask,
 	const char *label)
@@ -748,6 +749,14 @@ static void DrawCompassArrow(
 	{
 		return;
 	}
+	// Saturate according to dist from screen edge
+	int xDist = abs(pos.x - playerPos.x) - r.Size.x / 2;
+	int yDist = abs(pos.y - playerPos.y) - r.Size.y / 2;
+	int lDist;
+	xDist > yDist ? lDist = xDist: (lDist = yDist);
+	HSV hsv = { -1.0, 1.0,
+		2.0 - 1.5 * MIN(lDist, COMP_SATURATE_DIST) / COMP_SATURATE_DIST };
+	mask = ColorTint(mask, hsv);
 	Vec2i textPos = Vec2iZero();
 	// Find which edge of screen is the best
 	bool hasDrawn = false;

--- a/src/cdogs/hud.c
+++ b/src/cdogs/hud.c
@@ -395,10 +395,13 @@ static void DrawHealth(
 	HSV hsv = { 0.0, 1.0, 1.0 };
 	color_t barColor;
 	int health = actor->health;
+	int lastHealth = actor->lastHealth;
 	const int maxHealth = ActorGetCharacter(actor)->maxHealth;
-	int innerWidth;
+	int innerWidthLastHealth;
+	int innerWidthCurrentHealth;
 	color_t backColor = { 50, 0, 0, 255 };
-	innerWidth = MAX(1, size.x * health / maxHealth);
+	innerWidthLastHealth = MAX(1, size.x * lastHealth / maxHealth);
+	innerWidthCurrentHealth = MAX(1, size.x * health / maxHealth);
 	if (actor->poisoned)
 	{
 		hsv.h = 120.0;
@@ -411,10 +414,26 @@ static void DrawHealth(
 		hsv.h =
 			((maxHealthHue - minHealthHue) * health / maxHealth + minHealthHue);
 	}
+	if (lastHealth > health)
+	{
+		barColor = colorRed;
+		DrawGauge(
+				device, gaugePos, size, innerWidthLastHealth, barColor, backColor,
+				hAlign, vAlign);
+		backColor.a = 0;
+	}
 	barColor = ColorTint(colorWhite, hsv);
 	DrawGauge(
-		device, gaugePos, size, innerWidth, barColor, backColor,
+		device, gaugePos, size, innerWidthCurrentHealth, barColor, backColor,
 		hAlign, vAlign);
+	if (lastHealth < health)
+	{
+		barColor = colorGreen;
+		barColor.a = 255 * lastHealth / (double) health;
+		DrawGauge(
+				device, gaugePos, size, innerWidthLastHealth, barColor, backColor,
+				hAlign, vAlign);
+	}
 	sprintf(s, "%d", health);
 
 	FontOpts opts = FontOptsNew();

--- a/src/cdogs/hud.c
+++ b/src/cdogs/hud.c
@@ -399,6 +399,7 @@ static void DrawHealth(
 	const int maxHealth = ActorGetCharacter(actor)->maxHealth;
 	int innerWidthLastHealth;
 	int innerWidthCurrentHealth;
+	int innerWidth;
 	color_t backColor = { 50, 0, 0, 255 };
 	innerWidthLastHealth = MAX(1, size.x * lastHealth / maxHealth);
 	innerWidthCurrentHealth = MAX(1, size.x * health / maxHealth);
@@ -418,22 +419,24 @@ static void DrawHealth(
 	{
 		barColor = colorRed;
 		DrawGauge(
-				device, gaugePos, size, innerWidthLastHealth, barColor, backColor,
-				hAlign, vAlign);
+				device, gaugePos, size, innerWidthLastHealth, barColor,
+				backColor, hAlign, vAlign);
 		backColor.a = 0;
 	}
-	barColor = ColorTint(colorWhite, hsv);
-	DrawGauge(
-		device, gaugePos, size, innerWidthCurrentHealth, barColor, backColor,
-		hAlign, vAlign);
-	if (lastHealth < health)
+	else if (lastHealth < health)
 	{
 		barColor = colorGreen;
-		barColor.a = 255 * lastHealth / (double) health;
 		DrawGauge(
-				device, gaugePos, size, innerWidthLastHealth, barColor, backColor,
-				hAlign, vAlign);
+				device, gaugePos, size, innerWidthCurrentHealth, barColor,
+				backColor, hAlign, vAlign);
+		backColor.a = 0;
 	}
+	lastHealth < health ? innerWidth = innerWidthLastHealth:
+		(innerWidth = innerWidthCurrentHealth); 
+	barColor = ColorTint(colorWhite, hsv);
+	DrawGauge(
+		device, gaugePos, size, innerWidth, barColor, backColor,
+		hAlign, vAlign);
 	sprintf(s, "%d", health);
 
 	FontOpts opts = FontOptsNew();

--- a/src/cdogs/hud.c
+++ b/src/cdogs/hud.c
@@ -344,8 +344,12 @@ static void DrawWeaponStatus(
 	{
 		const Vec2i gaugePos = Vec2iAdd(pos, Vec2iNew(-1 + GUN_ICON_PAD, -1));
 		const Vec2i size = Vec2iNew(GAUGE_WIDTH - GUN_ICON_PAD, FontH() + 2);
-		const color_t barColor = { 0, 0, 255, 255 };
 		const int maxLock = weapon->Gun->Lock;
+		color_t barColor;
+		const double reloadProgressColorMod = 0.5 +
+			0.5 * (weapon->lock / (double) maxLock);
+		HSV hsv = { 0.0, 1.0, reloadProgressColorMod };
+		barColor = ColorTint(colorWhite, hsv);
 		int innerWidth;
 		color_t backColor = { 128, 128, 128, 255 };
 		if (maxLock == 0)


### PR DESCRIPTION
Handling issues #404 and #360, AKA "peripheral HUD". These changes are designed to make the HUD more intuitive.

I opted for Diablo/Bloodborne-style health gauge animations: when health is lost, the player's previous health is rendered as a shrinking red bar underneath their actual health to give a visual representation of how much health was lost. Likewise, similar behavior was applied to gaining health.

Objective markers now desaturate based on distance from the player's viewport. I played through a few campaigns with this and found it very helpful.

The ammo gauge's color has been altered to change based on reload time. Not sure I'm 100% happy with it yet, but the code there should be a step in the right direction.

I tried not to take too many creative liberties. Apologies in advance if these are outside the vision you had for C-Dogs!