### PR TITLE
Implemented Windows deployment, resolve #348

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,4 @@ deploy:
   file: "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.{tar.gz,rpm,deb}"
   on:
     repo: neverscaired/cdogs-sdl
+    condition: $CC = gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ before_deploy:
   - sudo make package
   - "sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*"
   # GCW-Zero
-  - bash build/travis-ci/install-gcw0-toolchain.sh --force
-  - ls -R  /opt/gcw0-toolchain
+  - bash build/travis-ci/install-gcw0-toolchain.sh
   - sh make_gcw0.sh
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_deploy:
   - "sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*"
   # GCW-Zero
   - bash build/travis-ci/install-gcw0-toolchain.sh
+  - ls -R  /opt/gcw0-toolchain
   - sh make_gcw0.sh
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,5 @@
 language: c
 
-os:
-  - linux
-  - osx
-
-dist: trusty
-sudo: required
-
 compiler:
   - gcc
   - clang
@@ -16,42 +9,42 @@ addons:
     sources:
     - ubuntu-toolchain-r-test
     packages:
+    - gcc-4.8
     - gcc-multilib
+    - libstdc++6:i386
+    - libc6:i386
     - rpm
-    - libsdl2-dev
-    - libsdl2-image-dev
-    - libsdl2-mixer-dev
-#cache:
-#  directories:
-#  - "/opt/gcw0-toolchain"
 
+before_install:
+  - bash build/travis-ci/install-sdl2.sh
+cache:
+  directories:
+  - /opt/gcw0-toolchain
 before_script:
+    # force newer gcc version
+  - if [ "$CC" = "gcc" ]; then export CC="gcc-4.8"; fi
+    # show which tests failed
   - export CTEST_OUTPUT_ON_FAILURE=1
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update --quieter ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc48 sdl2 sdl2_mixer sdl2_image ; fi
 
 script:
-  - cmake . -Wno-dev
+  - cmake .
   - make -j2
-  #TODO: For some reasons tests fail on osx. Hope it will be fixed some day
-#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test ; fi
-  - make test 
+  - make test
 before_deploy:
   - sudo make package
-#Debug message for osx
-  - ls $TRAVIS_BUILD_DIR 
-  - sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*
+  - "sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*"
+  # GCW-Zero
   - bash build/travis-ci/install-gcw0-toolchain.sh
   - sh make_gcw0.sh
-
 deploy:
   provider: releases
   api_key:
     secure: dqMASSgQxkNNuDtP7ipk2PonizZEYAufuN3trzu51l+j0JsFW5rk3yjMYeZUUvFcCokTFBtMf97F+1k7evw5M7EBm8E84BHuGzlMmz4eU8gBa0RaCdOYNeA0VMUNfgAMIiNqmRNG6qG+1othmh/IgdV1UYyAIT3Z1n00ALbeNZlI+KLZvlNWO/x6B39KWAoB3PXPAk2/vwsOJ6vf4Re8jOUcvvJYnrXRvpL48+xf76ZmVxdyQ9OVPwV6Pr5ahnd8u1ym6J/0qlxyK08SYvXumVuYGO7BnNH1i46gIimJMdkpswWTHYrlp46qPFgU0UpQZgdcXNUG0NyeNKTMbrZVwIEV3WPnQdz5v3+svV5OPJGDcm9TqAqET/CGXkTNgII3qVe6wqu6ZVH0P9bBgynJTHPS37IBE0KrsuCC3ZadaWOL4uEcrXsoPPnmk3ojdoZC6+cyRusW1oDUxeME8THokUJjEJEuXOlqQOQreOG+gyzFlzJWm8MTtVQtgBsKvI2ptGY0Qqobi+1Cnv7F29QD7p649F1T7uC12uPVNlkZUdGk9RNJacs4F9MLa5wDQ7yyBsO1v+iSjaFURWw+b4VUnWdE8g0vJQh2IoyGMCc3Cqy/rBYP4R3p7vl3NyJkf30z0ocS9InjAtKyh/wFZ3Oa/h8KiBGL7PiFZBTB+P/5xtM=
   file_glob: true
-  file: 
-    - "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.{tar.gz,rpm,deb}"
+  file:
+    - "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.tar.gz"
     - "$TRAVIS_BUILD_DIR/gcw0build/cdogs-sdl.opk"
+  skip_cleanup: true
   on:
     tags: true
-    condition: $CC = gcc
+    condition: $CC = gcc-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_deploy:
 - sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*
 deploy:
   provider: releases
+  skip_cleanup: true
   api_key:
     secure: dqMASSgQxkNNuDtP7ipk2PonizZEYAufuN3trzu51l+j0JsFW5rk3yjMYeZUUvFcCokTFBtMf97F+1k7evw5M7EBm8E84BHuGzlMmz4eU8gBa0RaCdOYNeA0VMUNfgAMIiNqmRNG6qG+1othmh/IgdV1UYyAIT3Z1n00ALbeNZlI+KLZvlNWO/x6B39KWAoB3PXPAk2/vwsOJ6vf4Re8jOUcvvJYnrXRvpL48+xf76ZmVxdyQ9OVPwV6Pr5ahnd8u1ym6J/0qlxyK08SYvXumVuYGO7BnNH1i46gIimJMdkpswWTHYrlp46qPFgU0UpQZgdcXNUG0NyeNKTMbrZVwIEV3WPnQdz5v3+svV5OPJGDcm9TqAqET/CGXkTNgII3qVe6wqu6ZVH0P9bBgynJTHPS37IBE0KrsuCC3ZadaWOL4uEcrXsoPPnmk3ojdoZC6+cyRusW1oDUxeME8THokUJjEJEuXOlqQOQreOG+gyzFlzJWm8MTtVQtgBsKvI2ptGY0Qqobi+1Cnv7F29QD7p649F1T7uC12uPVNlkZUdGk9RNJacs4F9MLa5wDQ7yyBsO1v+iSjaFURWw+b4VUnWdE8g0vJQh2IoyGMCc3Cqy/rBYP4R3p7vl3NyJkf30z0ocS9InjAtKyh/wFZ3Oa/h8KiBGL7PiFZBTB+P/5xtM=
   file: "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.{tar.gz,rpm,deb}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
     - libsdl2-mixer-dev
 cache:
   directories:
-#  - "/opt/gcw0-toolchain"
+  - "/opt/gcw0-toolchain"
 
 before_script:
   - export CTEST_OUTPUT_ON_FAILURE=1
@@ -33,23 +33,25 @@ before_script:
 script:
   - cmake . -Wno-dev
   - make -j2
-  - #TODO: For some reasons tests fail on osx. Hope it will be fixed some day
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test ; fi
-
+  #TODO: For some reasons tests fail on osx. Hope it will be fixed some day
+#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test ; fi
+  - make test 
 before_deploy:
   - sudo make package
 #Debug message for osx
   - ls $TRAVIS_BUILD_DIR 
   - sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*
-#  - bash build/travis-ci/install-gcw0-toolchain.sh
-#  - sh make_gcw0.sh
+  - bash build/travis-ci/install-gcw0-toolchain.sh
+  - sh make_gcw0.sh
 
 deploy:
   provider: releases
   api_key:
     secure: dqMASSgQxkNNuDtP7ipk2PonizZEYAufuN3trzu51l+j0JsFW5rk3yjMYeZUUvFcCokTFBtMf97F+1k7evw5M7EBm8E84BHuGzlMmz4eU8gBa0RaCdOYNeA0VMUNfgAMIiNqmRNG6qG+1othmh/IgdV1UYyAIT3Z1n00ALbeNZlI+KLZvlNWO/x6B39KWAoB3PXPAk2/vwsOJ6vf4Re8jOUcvvJYnrXRvpL48+xf76ZmVxdyQ9OVPwV6Pr5ahnd8u1ym6J/0qlxyK08SYvXumVuYGO7BnNH1i46gIimJMdkpswWTHYrlp46qPFgU0UpQZgdcXNUG0NyeNKTMbrZVwIEV3WPnQdz5v3+svV5OPJGDcm9TqAqET/CGXkTNgII3qVe6wqu6ZVH0P9bBgynJTHPS37IBE0KrsuCC3ZadaWOL4uEcrXsoPPnmk3ojdoZC6+cyRusW1oDUxeME8THokUJjEJEuXOlqQOQreOG+gyzFlzJWm8MTtVQtgBsKvI2ptGY0Qqobi+1Cnv7F29QD7p649F1T7uC12uPVNlkZUdGk9RNJacs4F9MLa5wDQ7yyBsO1v+iSjaFURWw+b4VUnWdE8g0vJQh2IoyGMCc3Cqy/rBYP4R3p7vl3NyJkf30z0ocS9InjAtKyh/wFZ3Oa/h8KiBGL7PiFZBTB+P/5xtM=
   file_glob: true
-  file: "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.{tar.gz,rpm,deb}"
+  file: 
+    - "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.{tar.gz,rpm,deb}"
+    - "$TRAVIS_BUILD_DIR/gcw0build/cdogs-sdl.opk"
   on:
     tags: true
     condition: $CC = gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: c
+
 os:
-- linux
-- osx
+  - linux
+  - osx
+
 dist: trusty
 sudo: required
+
 compiler:
-- gcc
-- clang
+  - gcc
+  - clang
+
 addons:
   apt:
     sources:
@@ -18,28 +22,34 @@ addons:
     - libsdl2-image-dev
     - libsdl2-mixer-dev
 cache:
-  directories: 
+  directories:
+#  - "/opt/gcw0-toolchain"
+
 before_script:
-- export CTEST_OUTPUT_ON_FAILURE=1
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update --quieter ; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc48 sdl2 sdl2_mixer sdl2_image  ;
-  fi
+  - export CTEST_OUTPUT_ON_FAILURE=1
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update --quieter ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc48 sdl2 sdl2_mixer sdl2_image ; fi
+
 script:
-- cmake . -Wno-dev
-- make -j2
-- 
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test ; fi
+  - cmake . -Wno-dev
+  - make -j2
+  - #TODO: For some reasons tests fail on osx. Hope it will be fixed some day
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test ; fi
+
 before_deploy:
-- sudo make package
-- ls $TRAVIS_BUILD_DIR
-- sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*
+  - sudo make package
+#Debug message for osx
+  - ls $TRAVIS_BUILD_DIR 
+  - sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*
+#  - bash build/travis-ci/install-gcw0-toolchain.sh
+#  - sh make_gcw0.sh
+
 deploy:
   provider: releases
-  skip_cleanup: true
-  tags:true
   api_key:
     secure: dqMASSgQxkNNuDtP7ipk2PonizZEYAufuN3trzu51l+j0JsFW5rk3yjMYeZUUvFcCokTFBtMf97F+1k7evw5M7EBm8E84BHuGzlMmz4eU8gBa0RaCdOYNeA0VMUNfgAMIiNqmRNG6qG+1othmh/IgdV1UYyAIT3Z1n00ALbeNZlI+KLZvlNWO/x6B39KWAoB3PXPAk2/vwsOJ6vf4Re8jOUcvvJYnrXRvpL48+xf76ZmVxdyQ9OVPwV6Pr5ahnd8u1ym6J/0qlxyK08SYvXumVuYGO7BnNH1i46gIimJMdkpswWTHYrlp46qPFgU0UpQZgdcXNUG0NyeNKTMbrZVwIEV3WPnQdz5v3+svV5OPJGDcm9TqAqET/CGXkTNgII3qVe6wqu6ZVH0P9bBgynJTHPS37IBE0KrsuCC3ZadaWOL4uEcrXsoPPnmk3ojdoZC6+cyRusW1oDUxeME8THokUJjEJEuXOlqQOQreOG+gyzFlzJWm8MTtVQtgBsKvI2ptGY0Qqobi+1Cnv7F29QD7p649F1T7uC12uPVNlkZUdGk9RNJacs4F9MLa5wDQ7yyBsO1v+iSjaFURWw+b4VUnWdE8g0vJQh2IoyGMCc3Cqy/rBYP4R3p7vl3NyJkf30z0ocS9InjAtKyh/wFZ3Oa/h8KiBGL7PiFZBTB+P/5xtM=
+  file_glob: true
   file: "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.{tar.gz,rpm,deb}"
   on:
-    repo: neverscaired/cdogs-sdl
+    tags: true
     condition: $CC = gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,50 +1,42 @@
 language: c
-
+os:
+- linux
+- osx
+dist: trusty
+sudo: required
 compiler:
-  - gcc
-  - clang
-
+- gcc
+- clang
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     packages:
-    - gcc-4.8
     - gcc-multilib
-    - libstdc++6:i386
-    - libc6:i386
     - rpm
-
-before_install:
-  - bash build/travis-ci/install-sdl2.sh
+    - libsdl2-dev
+    - libsdl2-image-dev
+    - libsdl2-mixer-dev
 cache:
-  directories:
-  - /opt/gcw0-toolchain
+  directories: 
 before_script:
-    # force newer gcc version
-  - if [ "$CC" = "gcc" ]; then export CC="gcc-4.8"; fi
-    # show which tests failed
-  - export CTEST_OUTPUT_ON_FAILURE=1
-
+- export CTEST_OUTPUT_ON_FAILURE=1
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update --quieter ; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc48 sdl2 sdl2_mixer sdl2_image
+  ; fi
 script:
-  - cmake .
-  - make -j2
-  - make test
+- cmake .
+- make -j2
+- 
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test ; fi
 before_deploy:
-  - sudo make package
-  - "sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*"
-  # GCW-Zero
-  - bash build/travis-ci/install-gcw0-toolchain.sh
-  - sh make_gcw0.sh
+- sudo make package
+- ls $TRAVIS_BUILD_DIR
+- sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*
 deploy:
   provider: releases
   api_key:
-    secure: Rus8lTl0EnVqM6PXwleQ8cffjMTMY1gHGwVdbGsu8cWaDgAWQ86TFgGBbV+x12z9floDPzI7Z1K/entktkiSWQyRPIa9jQfJBIomNABhIykUvpRsL026Cs8TysI4L4hrTvFev10QI28RFyZvUDBT8yytowFsuU5Pfb4n7kDIisQ=
-  file_glob: true
-  file:
-    - "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.tar.gz"
-    - "$TRAVIS_BUILD_DIR/gcw0build/cdogs-sdl.opk"
-  skip_cleanup: true
+    secure: T23Hn6je1Kx3JhQC6w2SxKNVJHXLgLQDg1WzGcWFTmyFTIbBtDuH5mx0AQR2Gl15mTmkzaDu7Zrowb3xBE1kk3hHV5XqmP8Wmb4YWIMjcuHXuQ+dhQDZo/tgiRMjGqFAr9u7NUhauBij0XXnS4rC8LPGjgnIUAfPGDgPCIXVSRcv2BYPA/vLF7DW9bIIq9Oz7bwaVXeVzkD5q/a/k5hBRURuCPHB+xA8F30Vde7YjZTa9NkyaWlA3M5k14q9HpwBgHSsj2te8Vsv9fcH3QuRuyGKAIle0NvoxvzfMhFmJI9yc6tRn+kHqkAvfg0WYsJygQ0oUmvCvbk76JyuvTca6OlFwEJM0sHiO98iOgXyy+zrKK7dCUbZmsgFqubm3r/qqyN5RpxYTz8qFdOHeLwMhA4KtpWFdRpVAPpRBKoeMRfXB0mgBh/763KBk8owyepvOI045e7PoFtwxYSylnp5u6dU22fCrjEyPd3jdJ1wWJk19PfqkQzcG64wcyBC0gZtx4nAsXgyomFoJh0yJoVFUkFDRV1WxrlS3Zu5Rj9Iz5t0pKsLuyTVH576s9eWfYPcW5lVUKBM5JotICKzsRheV3FOdn380KlnfCZ2Y+QhT31Ppe1nejCuhonJFh1GrUqbq3Srn5GMJAOcQKTej+Hi8k47gRzxM3ln/q2XL2vHmsg=
+  file: "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.{tar.gz,rpm,deb}"
   on:
-    tags: true
-    condition: $CC = gcc-4.8
+    repo: neverscaired/cdogs-sdl

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ cache:
 before_script:
 - export CTEST_OUTPUT_ON_FAILURE=1
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update --quieter ; fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc48 sdl2 sdl2_mixer sdl2_image
-  ; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc48 sdl2 sdl2_mixer sdl2_image  ;
+  fi
 script:
 - cmake .
 - make -j2
@@ -36,7 +36,7 @@ before_deploy:
 deploy:
   provider: releases
   api_key:
-    secure: T23Hn6je1Kx3JhQC6w2SxKNVJHXLgLQDg1WzGcWFTmyFTIbBtDuH5mx0AQR2Gl15mTmkzaDu7Zrowb3xBE1kk3hHV5XqmP8Wmb4YWIMjcuHXuQ+dhQDZo/tgiRMjGqFAr9u7NUhauBij0XXnS4rC8LPGjgnIUAfPGDgPCIXVSRcv2BYPA/vLF7DW9bIIq9Oz7bwaVXeVzkD5q/a/k5hBRURuCPHB+xA8F30Vde7YjZTa9NkyaWlA3M5k14q9HpwBgHSsj2te8Vsv9fcH3QuRuyGKAIle0NvoxvzfMhFmJI9yc6tRn+kHqkAvfg0WYsJygQ0oUmvCvbk76JyuvTca6OlFwEJM0sHiO98iOgXyy+zrKK7dCUbZmsgFqubm3r/qqyN5RpxYTz8qFdOHeLwMhA4KtpWFdRpVAPpRBKoeMRfXB0mgBh/763KBk8owyepvOI045e7PoFtwxYSylnp5u6dU22fCrjEyPd3jdJ1wWJk19PfqkQzcG64wcyBC0gZtx4nAsXgyomFoJh0yJoVFUkFDRV1WxrlS3Zu5Rj9Iz5t0pKsLuyTVH576s9eWfYPcW5lVUKBM5JotICKzsRheV3FOdn380KlnfCZ2Y+QhT31Ppe1nejCuhonJFh1GrUqbq3Srn5GMJAOcQKTej+Hi8k47gRzxM3ln/q2XL2vHmsg=
+    secure: dqMASSgQxkNNuDtP7ipk2PonizZEYAufuN3trzu51l+j0JsFW5rk3yjMYeZUUvFcCokTFBtMf97F+1k7evw5M7EBm8E84BHuGzlMmz4eU8gBa0RaCdOYNeA0VMUNfgAMIiNqmRNG6qG+1othmh/IgdV1UYyAIT3Z1n00ALbeNZlI+KLZvlNWO/x6B39KWAoB3PXPAk2/vwsOJ6vf4Re8jOUcvvJYnrXRvpL48+xf76ZmVxdyQ9OVPwV6Pr5ahnd8u1ym6J/0qlxyK08SYvXumVuYGO7BnNH1i46gIimJMdkpswWTHYrlp46qPFgU0UpQZgdcXNUG0NyeNKTMbrZVwIEV3WPnQdz5v3+svV5OPJGDcm9TqAqET/CGXkTNgII3qVe6wqu6ZVH0P9bBgynJTHPS37IBE0KrsuCC3ZadaWOL4uEcrXsoPPnmk3ojdoZC6+cyRusW1oDUxeME8THokUJjEJEuXOlqQOQreOG+gyzFlzJWm8MTtVQtgBsKvI2ptGY0Qqobi+1Cnv7F29QD7p649F1T7uC12uPVNlkZUdGk9RNJacs4F9MLa5wDQ7yyBsO1v+iSjaFURWw+b4VUnWdE8g0vJQh2IoyGMCc3Cqy/rBYP4R3p7vl3NyJkf30z0ocS9InjAtKyh/wFZ3Oa/h8KiBGL7PiFZBTB+P/5xtM=
   file: "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.{tar.gz,rpm,deb}"
   on:
     repo: neverscaired/cdogs-sdl

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,9 @@ addons:
     - libsdl2-dev
     - libsdl2-image-dev
     - libsdl2-mixer-dev
-cache:
-  directories:
-  - "/opt/gcw0-toolchain"
+#cache:
+#  directories:
+#  - "/opt/gcw0-toolchain"
 
 before_script:
   - export CTEST_OUTPUT_ON_FAILURE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
 - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install gcc48 sdl2 sdl2_mixer sdl2_image  ;
   fi
 script:
-- cmake .
+- cmake . -Wno-dev
 - make -j2
 - 
 - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make test ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_deploy:
 deploy:
   provider: releases
   skip_cleanup: true
+  tags:true
   api_key:
     secure: dqMASSgQxkNNuDtP7ipk2PonizZEYAufuN3trzu51l+j0JsFW5rk3yjMYeZUUvFcCokTFBtMf97F+1k7evw5M7EBm8E84BHuGzlMmz4eU8gBa0RaCdOYNeA0VMUNfgAMIiNqmRNG6qG+1othmh/IgdV1UYyAIT3Z1n00ALbeNZlI+KLZvlNWO/x6B39KWAoB3PXPAk2/vwsOJ6vf4Re8jOUcvvJYnrXRvpL48+xf76ZmVxdyQ9OVPwV6Pr5ahnd8u1ym6J/0qlxyK08SYvXumVuYGO7BnNH1i46gIimJMdkpswWTHYrlp46qPFgU0UpQZgdcXNUG0NyeNKTMbrZVwIEV3WPnQdz5v3+svV5OPJGDcm9TqAqET/CGXkTNgII3qVe6wqu6ZVH0P9bBgynJTHPS37IBE0KrsuCC3ZadaWOL4uEcrXsoPPnmk3ojdoZC6+cyRusW1oDUxeME8THokUJjEJEuXOlqQOQreOG+gyzFlzJWm8MTtVQtgBsKvI2ptGY0Qqobi+1Cnv7F29QD7p649F1T7uC12uPVNlkZUdGk9RNJacs4F9MLa5wDQ7yyBsO1v+iSjaFURWw+b4VUnWdE8g0vJQh2IoyGMCc3Cqy/rBYP4R3p7vl3NyJkf30z0ocS9InjAtKyh/wFZ3Oa/h8KiBGL7PiFZBTB+P/5xtM=
   file: "$TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.{tar.gz,rpm,deb}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_deploy:
   - sudo make package
   - "sudo chown $USER $TRAVIS_BUILD_DIR/C-Dogs*SDL-*-Linux.*"
   # GCW-Zero
-  - bash build/travis-ci/install-gcw0-toolchain.sh
+  - bash build/travis-ci/install-gcw0-toolchain.sh --force
   - ls -R  /opt/gcw0-toolchain
   - sh make_gcw0.sh
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,8 +36,23 @@ build_script:
 
 after_build:
   - mingw32-make test
+  - mingw32-make package
+  - dir
 
 cache:
 - SDL2-devel-2.0.4-mingw.tar.gz
 - SDL2_mixer-devel-2.0.1-mingw.tar.gz
 - SDL2_image-devel-2.0.1-mingw.tar.gz
+
+artifacts:
+  - path: /.\C-Dogs*.exe/
+
+deploy:
+  provider: GitHub
+  description: $(appveyor_build_version)
+  auth_token:
+    secure: czG+/wj3tLPZrWhAOymrn7GQTUpJRIJcpyhTVf8VuFAyUvU63dtrZFVWmx2G9m41
+  prerelease: false
+  force_update: true 	#to be in piece with Travis CI
+  on:
+    appveyor_repo_tag: true

--- a/build/travis-ci/install-gcw0-toolchain.sh
+++ b/build/travis-ci/install-gcw0-toolchain.sh
@@ -1,17 +1,36 @@
 #!/bin/sh
 set -e
 
-if [[ "$1" == "--force" ]]
-then
-FORCE_INSTALL=true
-fi
+GCW0_TOOLCHAIN_PATH="/opt/gcw0-toolchain"
 
-# check to see if toolchain folder is empty
-if [[ ! -d "/opt/gcw0-toolchain" || "$FORCE_INSTALL" == "true" ]]; then
+function getToolchain {
+  echo "Starting building GCW-Zero..."
   if [ ! -f "opendingux-gcw0-toolchain.2014-08-20.tar.bz2" ]; then
     curl -O http://www.gcw-zero.com/files/opendingux-gcw0-toolchain.2014-08-20.tar.bz2
   fi
   (sudo mkdir -p /opt && sudo tar jxf opendingux-gcw0-toolchain.2014-08-20.tar.bz2 -C /opt)
+}
+
+if [[ "$1" == "--force" ]]
+then
+echo "Force build requested by --force."
+getToolchain
+exit
+fi
+
+# check to see if toolchain folder is empty
+if [[ -d "$GCW0_TOOLCHAIN_PATH"  ]]; then
+  if [[ -n "$(ls -A $GCW0_TOOLCHAIN_PATH)" ]]
+  then
+    echo "Toolchain exists. Skip building..."
+    exit
+  else
+  	echo "Toolchain dir exists buit it is empty..."
+  	getToolchain
+  	exit
+  fi
 else
-  echo "Using cached toolchain directory."
+	echo "Toolchain dir missing..."
+	getToolchain
+	exit
 fi

--- a/build/travis-ci/install-gcw0-toolchain.sh
+++ b/build/travis-ci/install-gcw0-toolchain.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 set -e
+
+if [[ "$1" == "--force" ]]
+then
+FORCE_INSTALL=true
+fi
+
 # check to see if toolchain folder is empty
-if [ ! -d "/opt/gcw0-toolchain" ]; then
+if [[ ! -d "/opt/gcw0-toolchain" || "$FORCE_INSTALL" == "true" ]]; then
   if [ ! -f "opendingux-gcw0-toolchain.2014-08-20.tar.bz2" ]; then
     curl -O http://www.gcw-zero.com/files/opendingux-gcw0-toolchain.2014-08-20.tar.bz2
   fi


### PR DESCRIPTION
After each tag assignment AppVeyor builds it and deploys just in related release.
Example: https://github.com/neverscaired/cdogs-sdl/releases/tag/WindowsDeployment
Now I'm working on OSX integration (there are some problems there). 
NOTE: Don't forget to change token from mine to yours in both files