### PR TITLE
Fixed INSTALL_PREFIX for Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ elseif(APPLE)
 else()
 	set(EXE_EXTENSION "")
 	set(LIB_EXTENSION ".so")
+	set(INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 endif()
 if(APPLE)
 	install(


### PR DESCRIPTION
as it got hard-coded to `.` which also can't be fixed via a `cmake -DINSTALL_PREFIX=` parameter as you overwrite it with a hard-coded value later in the script.