### PR TITLE
Added USE_SHARED_ENET parameter for Linux distributions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ SET(WEBSITE "http://cxong.github.io/cdogs-sdl/")
 
 option(DEBUG "Enable debug build" OFF)
 option(DEBUG_PROFILE "Enable debug profile build" OFF)
+option(USE_SHARED_ENET "Use system installed copy of enet" OFF)
 
 # check for crosscompiling (defined when using a toolchain file)
 if(CMAKE_CROSSCOMPILING)
@@ -81,7 +82,10 @@ IF(WIN32)
 ELSE()
     SET(ENet_LIBRARIES ${ENet_LIBRARY})
 ENDIF()
-INCLUDE_DIRECTORIES(src/cdogs/enet/include)
+
+IF(NOT USE_SHARED_ENET)
+    INCLUDE_DIRECTORIES(src/cdogs/enet/include)
+ENDIF()
 
 add_definitions(-DPB_FIELD_16BIT)	# Allow larger field numbers in nanopb
 include_directories(src/cdogs/proto/nanopb)

--- a/src/cdogs/CMakeLists.txt
+++ b/src/cdogs/CMakeLists.txt
@@ -217,8 +217,9 @@ set(NANOPB_HEADERS
     proto/nanopb/pb_encode.h
 )
 
-# enet
-ADD_SUBDIRECTORY(enet)
+IF(NOT USE_SHARED_ENET)
+    ADD_SUBDIRECTORY(enet)
+ENDIF()
 
 # proto
 include_directories(proto/nanopb)


### PR DESCRIPTION
This is based on the patch from @akien-mga http://sophie.aero.jussieu.fr/distrib/Mageia/cauldron/i586/by-pkgid/8769c31df9dc9a5eebb81327ad39b0ba/files/1 but made configurable so it doesn't disturb anyone.