### PR TITLE
Fix copyright statements for build/cmake/Copyright

### DIFF
--- a/build/cmake/Copyright.txt
+++ b/build/cmake/Copyright.txt
@@ -1,0 +1,59 @@
+CMake - Cross Platform Makefile Generator
+Copyright 2000-2014 Kitware, Inc.
+Copyright 2000-2011 Insight Software Consortium
+Copyright 2014 Justin Jacobs <jajdorkster@gmail.com>
+Copyright 2015 Cong Xu <congusbongus@gmail.com>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the names of Kitware, Inc., the Insight Software Consortium,
+  nor the names of their contributors may be used to endorse or promote
+  products derived from this software without specific prior written
+  permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+
+The above copyright and license notice applies to distributions of
+CMake in source and binary form.  Some source files contain additional
+notices of original copyright by their contributors; see each source
+for details.  Third-party software packages supplied with CMake under
+compatible licenses provide their own copyright notices documented in
+corresponding subdirectories.
+
+------------------------------------------------------------------------------
+
+CMake was initially developed by Kitware with the following sponsorship:
+
+ * National Library of Medicine at the National Institutes of Health
+   as part of the Insight Segmentation and Registration Toolkit (ITK).
+
+ * US National Labs (Los Alamos, Livermore, Sandia) ASC Parallel
+   Visualization Initiative.
+
+ * National Alliance for Medical Image Computing (NAMIC) is funded by the
+   National Institutes of Health through the NIH Roadmap for Medical Research,
+   Grant U54 EB005149.
+
+ * Kitware, Inc.

--- a/build/cmake/FindSDL2.cmake
+++ b/build/cmake/FindSDL2.cmake
@@ -26,9 +26,12 @@
 # correspond to the ./configure --prefix=$SDLDIR
 # used in building SDL.
 #
-
 #=============================================================================
-# Copyright 2014 Justin Jacobs
+# Copyright 2000-2014 Kitware, Inc.
+# Copyright 2000-2011 Insight Software Consortium
+# Copyright 2014 Justin Jacobs <jajdorkster@gmail.com>
+# Copyright 2015 Cong Xu <congusbongus@gmail.com>
+# All rights reserved.
 #
 # Distributed under the OSI-approved BSD License (the "License");
 # see accompanying file Copyright.txt for details.

--- a/build/cmake/FindSDL2_image.cmake
+++ b/build/cmake/FindSDL2_image.cmake
@@ -15,7 +15,11 @@
 # used in building SDL.
 #
 #=============================================================================
-# Copyright 2014 Justin Jacobs
+# Copyright 2000-2014 Kitware, Inc.
+# Copyright 2000-2011 Insight Software Consortium
+# Copyright 2014 Justin Jacobs <jajdorkster@gmail.com>
+# Copyright 2015 Cong Xu <congusbongus@gmail.com>
+# All rights reserved.
 #
 # Distributed under the OSI-approved BSD License (the "License");
 # see accompanying file Copyright.txt for details.

--- a/build/cmake/FindSDL2_mixer.cmake
+++ b/build/cmake/FindSDL2_mixer.cmake
@@ -15,7 +15,11 @@
 # used in building SDL.
 #
 #=============================================================================
-# Copyright 2014 Justin Jacobs
+# Copyright 2000-2014 Kitware, Inc.
+# Copyright 2000-2011 Insight Software Consortium
+# Copyright 2014 Justin Jacobs <jajdorkster@gmail.com>
+# Copyright 2015 Cong Xu <congusbongus@gmail.com>
+# All rights reserved.
 #
 # Distributed under the OSI-approved BSD License (the "License");
 # see accompanying file Copyright.txt for details.


### PR DESCRIPTION
The source code for build/cmake/FindSDL2* comes from
https://github.com/clintbellanger/flare-engine/ by Justin Jacobs copied
in 2014 from CMake.  The source files referred a Copyright.txt which is
https://github.com/Kitware/CMake/blob/f2ec464fe030b562134f9b66a503735cca08f695/Copyright.txt

Copy the CMake Copyright.txt as it was in 2014 to
build/cmake/Copyright.txt
Update Copyrights statements for work by:
* Justin Jacobs on https://github.com/clintbellanger/flare-engine/
* Cong Xu here

Part of #89 