### PR TITLE
Exclude files from generated tarballs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/appveyor.yml export-ignore
+/appveyor.yml.cmake export-ignore
+/wiki* export-ignore


### PR DESCRIPTION
github and Debian "git buildpackage" create tarballs from the git
repository using "git archive". Exclude some of the files from the repo
by adding them to .gitattribute:

    /.gitattributes
    /.gitignore
    /.travis.yml
    /appveyor.yml
    /appveyor.yml.cmake
    /wiki*

Tested using:
    git archive --worktree-attributes HEAD|tar -t

Signed-off-by: Antoine Musso <hashar@free.fr>