### PR TITLE
Use raw.githubusercontent.com in appdata.xml

### DIFF
--- a/build/linux/cdogs-sdl.appdata.xml
+++ b/build/linux/cdogs-sdl.appdata.xml
@@ -21,7 +21,7 @@
   <screenshots>
     <screenshot
     type="default">https://raw.githubusercontent.com/cxong/cdogs-sdl/master/wiki/images/game_screen.png</screenshot>
-    <screenshot>https://raw.github.com/cxong/cdogs-sdl/master/wiki/images/screenshots/hqx_new.png</screenshot>
+    <screenshot>https://raw.githubusercontent.com/cxong/cdogs-sdl/master/wiki/images/screenshots/hqx_new.png</screenshot>
     <screenshot>https://raw.githubusercontent.com/cxong/cdogs-sdl/master/wiki/images/screenshots/quick_play.png</screenshot>
   </screenshots>
 </component>


### PR DESCRIPTION
raw.github.com is deprecated and redirects to raw.githubusercontent.com.
Adjust the screenshot URL in build/linux/cdogs-sdl.appdata.xml

Signed-off-by: Antoine Musso <hashar@free.fr>