### PR TITLE
issue #548: Unpausing shouldn't trigger button action

### DIFF
--- a/src/game.c
+++ b/src/game.c
@@ -396,9 +396,11 @@ static void RunGameInput(GameLoopData *data)
 	// - escape was pressed, or
 	// - window lost focus
 	// - controller unplugged
+	// If the game is paused, unpause if a button is released
 	// If the game was not paused, enter pause mode
 	// If the game was paused and escape was pressed, exit the game
-	if (AnyButton(cmdAll))
+	if (rData->pausingDevice != INPUT_DEVICE_UNSET
+	    && AnyButton(lastCmdAll) && !AnyButton(cmdAll))
 	{
 		rData->pausingDevice = INPUT_DEVICE_UNSET;
 	}


### PR DESCRIPTION
Check for button release when unpausing to prevent regular button action
from firing. This should solve #548 