### PR TITLE
Enable multiprocessor compiling on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ ENDIF()
 add_definitions(-DPB_FIELD_16BIT)	# Allow larger field numbers in nanopb
 include_directories(src/cdogs/proto/nanopb)
 if(MSVC)
-	ADD_DEFINITIONS(-W4 -WX -wd"4996" -wd"4204")
+	ADD_DEFINITIONS(-MP -W4 -WX -wd"4996" -wd"4204")
 else()
 	add_definitions(
 		-fsigned-char


### PR DESCRIPTION
Enable [multiprocessor compiling](https://docs.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes?view=vs-2019) on MSVC. Huge compilation time improvement.