### PR TITLE
Fix heap corruption with hair style name

### DIFF
--- a/src/cdogs/character.c
+++ b/src/cdogs/character.c
@@ -307,11 +307,10 @@ void CharacterShuffleAppearance(Character *c)
 			charClass - gCharacterClasses.Classes.size);
 	}
 	CFREE(c->Hair);
-	CSTRDUP(
-		c->Hair,
-		*(char **)CArrayGet(
-			&gPicManager.hairstyleNames,
-			rand() % gPicManager.hairstyleNames.size));
+	const char *hairStyleName = *(char **)CArrayGet(
+		&gPicManager.hairstyleNames,
+		rand() % gPicManager.hairstyleNames.size);
+	CSTRDUP(c->Hair, hairStyleName);
 	c->Colors.Skin = RandomColor();
 	c->Colors.Arms = RandomColor();
 	c->Colors.Body = RandomColor();


### PR DESCRIPTION
Fix issue #608 

Because `CSTRDUP` is a macro and not a function call, `CArrayGet` got called twice with different `rand()` value - first in memory allocation and then in copying. It meant that memory was reserved for other name than what was actually copied leading to potential buffer overflow.

In other words, `CSTRDUP` call got expanded to
```
	CMALLOC(c->Hair, strlen(*(char **)CArrayGet(
		&gPicManager.hairstyleNames,
		rand() % gPicManager.hairstyleNames.size)) + 1);
	strcpy(c->Hair, *(char **)CArrayGet(
		&gPicManager.hairstyleNames,
		rand() % gPicManager.hairstyleNames.size));
```