### PR TITLE
fix string overflow for long weapon descriptions

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -729,15 +729,15 @@ static void MenuDisplaySubmenus(const MenuSystem *ms)
 		for (int i = iStart; i < iEnd; i++)
 		{
 			const menu_t *subMenu = CArrayGet(&menu->u.normal.subMenus, i);
-			char nameBuf[256];
+			char nameBuf[512];
 			if (subMenu->type == MENU_TYPE_NORMAL &&
 				subMenu->u.normal.isSubmenusAlt)
 			{
-				sprintf(nameBuf, "%s \x10", subMenu->name);
+				snprintf(nameBuf, sizeof(nameBuf), "%s \x10", subMenu->name);
 			}
 			else
 			{
-				strcpy(nameBuf, subMenu->name);
+				snprintf(nameBuf, sizeof(nameBuf), "%s", subMenu->name);
 			}
 
 			switch (menu->u.normal.align)


### PR DESCRIPTION
Some weapons had a description longer than the text buffer (256 chars). This PR doubles the text buffer size and prevents overflow for longer strings. Just found this when starting the game for the first time and trying to select the Shotgun in the Sand campaign, the game crashed.

There is still a lot more code that uses strcpy and sprintf unchecked, and could cause crashes elsewhere (Just look at the compiler warnings)