### PR TITLE
Default STATIC for osdialog library

### DIFF
--- a/src/cdogsed/osdialog/CMakeLists.txt
+++ b/src/cdogsed/osdialog/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
     message(FATAL_ERROR "Cannot detect your system")
 endif()
 
-add_library(osdialog "${SOURCES}")
+add_library(osdialog STATIC "${SOURCES}")
 add_executable(osdialog_test ${SOURCES} test.c)
 
 if(MSVC)


### PR DESCRIPTION
This defaults CMake to build the bundled osdialog as a static library.
This helps prevent problems in operating systems such as Gentoo Linux
which assume dynamic linking and subsequently install cdogs-sdl with
broken dependencies.