### PR TITLE
Fix linker issues with gcc10 (fixes #658)

### DIFF
--- a/src/cdogs/log.c
+++ b/src/cdogs/log.c
@@ -32,6 +32,7 @@
 #include "rlutil/rlutil.h"
 #include "utils.h"
 
+FILE *gLogFile;
 
 typedef struct
 {

--- a/src/cdogs/log.h
+++ b/src/cdogs/log.h
@@ -60,7 +60,7 @@ void LogModuleSetLevel(const LogModule m, const LogLevel l);
 const char *LogLevelName(const LogLevel l);
 LogLevel StrLogLevel(const char *s);
 
-FILE *gLogFile;
+extern FILE *gLogFile;
 void LogInit(void);
 void LogOpenFile(const char *filename);
 void LogTerminate(void);


### PR DESCRIPTION
As described in the issue, this will solve issues when building with gcc10 (multiple definitions).