### PR TITLE
Fix minor weapon pickup bug

### DIFF
--- a/missions/custom/techdemo/spawnertest.cdogscpn/campaign.json
+++ b/missions/custom/techdemo/spawnertest.cdogscpn/campaign.json
@@ -1,7 +1,11 @@
 {
-	"Version": 4,
+	"Version": 16,
 	"Title": "Spawner Test",
 	"Author": "Cong",
 	"Description": "Testing some spawners",
+	"Ammo": true,
+	"WeaponPersist": false,
+	"SkipWeaponMenu": true,
+	"RandomPickups": false,
 	"Missions": 1
 }

--- a/missions/custom/techdemo/spawnertest.cdogscpn/characters.json
+++ b/missions/custom/techdemo/spawnertest.cdogscpn/characters.json
@@ -1,3 +1,4 @@
 {
+	"Version": 13,
 	"Characters": []
 }

--- a/missions/custom/techdemo/spawnertest.cdogscpn/missions.json
+++ b/missions/custom/techdemo/spawnertest.cdogscpn/missions.json
@@ -5,12 +5,8 @@
 		"Type": "Static",
 		"Width": 16,
 		"Height": 16,
-		"WallStyle": 2,
-		"FloorStyle": 9,
-		"RoomStyle": 9,
-		"ExitStyle": 1,
-		"KeyStyle": 0,
-		"DoorStyle": 0,
+		"ExitStyle": "plate",
+		"KeyStyle": "office",
 		"Objectives": [],
 		"Enemies": [],
 		"SpecialChars": [],
@@ -38,64 +34,115 @@
 		"Launcher",
 		"Pistol"],
 		"Song": "",
-		"WallColor": 8,
-		"FloorColor": 12,
-		"RoomColor": 8,
-		"AltColor": 9,
-		"Tiles": "1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1",
+		"TileClasses": {
+			"1": {
+				"Name": "wall",
+				"Type": "Wall",
+				"Style": "carbon",
+				"Mask": "000048ff",
+				"MaskAlt": "840084ff",
+				"CanWalk": false,
+				"IsOpaque": true,
+				"Shootable": true,
+				"IsRoom": false
+			},
+			"0": {
+				"Name": "tile",
+				"Type": "Floor",
+				"Style": "grid",
+				"Mask": "848484ff",
+				"MaskAlt": "840084ff",
+				"CanWalk": true,
+				"IsOpaque": false,
+				"Shootable": false,
+				"IsRoom": false
+			}
+		},
+		"Tiles": ["1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1",
+		"1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"],
+		"Access": ["0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0",
+		"0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0"],
 		"StaticItems": [{
-			"MapObject": "Bullets spawner",
-			"Positions": [[2,
-			2]]
+			"MapObject": "Bullets ammo spawner",
+			"Positions": [[2, 2]]
 		},
 		{
 			"MapObject": "Grenades spawner",
-			"Positions": [[4,
-			2]]
+			"Positions": [[4, 2]]
 		},
 		{
-			"MapObject": "Gas tank spawner",
-			"Positions": [[6,
-			2]]
+			"MapObject": "Gas tank ammo spawner",
+			"Positions": [[6, 2]]
 		},
 		{
-			"MapObject": "Shells spawner",
-			"Positions": [[8,
-			2]]
+			"MapObject": "Shells ammo spawner",
+			"Positions": [[8, 2]]
 		},
 		{
-			"MapObject": "Cells spawner",
-			"Positions": [[10,
-			2]]
+			"MapObject": "Cells ammo spawner",
+			"Positions": [[10, 2]]
 		},
 		{
-			"MapObject": "Frag grenades spawner",
-			"Positions": [[12,
-			2]]
+			"MapObject": "Frag grenades ammo spawner",
+			"Positions": [[12, 2]]
 		},
 		{
 			"MapObject": "Molotovs spawner",
-			"Positions": [[2,
-			4]]
+			"Positions": [[2, 4]]
 		},
 		{
-			"MapObject": "Mines spawner",
-			"Positions": [[4,
-			4],
-			[10,
-			4]]
+			"MapObject": "Mines ammo spawner",
+			"Positions": [[4, 4],
+			[10, 4]]
+		},
+		{
+			"MapObject": "Machine gun spawner",
+			"Positions": [[2, 6]]
+		},
+		{
+			"MapObject": "Shotgun spawner",
+			"Positions": [[4, 6]]
 		}],
-		"StaticWrecks": [],
 		"StaticCharacters": [],
 		"StaticObjectives": [],
 		"StaticKeys": [],
-		"Start": [0,
-		0],
-		"Exit": {
-			"Start": [0,
-			0],
-			"End": [0,
-			0]
-		}
+		"StaticPickups": [],
+		"Start": [0, 0],
+		"Exits": [{
+			"Rect": [10,
+			11,
+			5,
+			4],
+			"Mission": 1,
+			"Hidden": false
+		}]
 	}]
 }

--- a/src/cdogs/pickup.c
+++ b/src/cdogs/pickup.c
@@ -1,7 +1,7 @@
 /*
 	C-Dogs SDL
 	A port of the legendary (and fun) action/arcade cdogs.
-	Copyright (c) 2014-2015, 2017-2018 Cong Xu
+	Copyright (c) 2014-2015, 2017-2020 Cong Xu
 	All rights reserved.
 
 	Redistribution and use in source and binary forms, with or without
@@ -307,16 +307,6 @@ static bool TryPickupGun(
 			: StrWeaponClass(
 				  AmmoGetById(&gAmmo, p->class->u.Ammo.Id)->DefaultGun);
 
-	int ammoDeficit = 0;
-	const Ammo *ammo = NULL;
-	const int ammoId = wc->AmmoId;
-	if (ammoId >= 0)
-	{
-		ammo = AmmoGetById(&gAmmo, ammoId);
-		ammoDeficit = ammo->Amount * AMMO_STARTING_MULTIPLE -
-					  *(int *)CArrayGet(&a->ammo, ammoId);
-	}
-
 	if (!ActorHasGun(a, wc))
 	{
 		// Pickup gun
@@ -351,18 +341,24 @@ static bool TryPickupGun(
 
 	// If the player has less ammo than the default amount,
 	// replenish up to this amount
-	if (ammoDeficit > 0)
+	if (wc->AmmoId >= 0)
 	{
-		GameEvent e = GameEventNew(GAME_EVENT_ACTOR_ADD_AMMO);
-		e.u.AddAmmo.UID = a->uid;
-		e.u.AddAmmo.PlayerUID = a->PlayerUID;
-		e.u.AddAmmo.Ammo.Id = ammoId;
-		e.u.AddAmmo.Ammo.Amount = ammoDeficit;
-		e.u.AddAmmo.IsRandomSpawned = false;
-		GameEventsEnqueue(&gGameEvents, e);
+		const Ammo *ammo = AmmoGetById(&gAmmo, wc->AmmoId);
+		const int ammoDeficit = ammo->Amount * AMMO_STARTING_MULTIPLE -
+								*(int *)CArrayGet(&a->ammo, wc->AmmoId);
+		if (ammoDeficit > 0)
+		{
+			GameEvent e = GameEventNew(GAME_EVENT_ACTOR_ADD_AMMO);
+			e.u.AddAmmo.UID = a->uid;
+			e.u.AddAmmo.PlayerUID = a->PlayerUID;
+			e.u.AddAmmo.Ammo.Id = wc->AmmoId;
+			e.u.AddAmmo.Ammo.Amount = ammoDeficit;
+			e.u.AddAmmo.IsRandomSpawned = false;
+			GameEventsEnqueue(&gGameEvents, e);
 
-		// Also play an ammo pickup sound
-		*sound = ammo->Sound;
+			// Also play an ammo pickup sound
+			*sound = ammo->Sound;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
Fixes issue #660
Added a check to see if the actor already has the gun to prevent spawning the currently equipped gun. Even though ActorReplaceGun returns early, current gun is still marked for replacement and a new pickup is spawned. 

This also changes how picking up a gun behaves when that gun is currently equipped. Before this change, the gun pickup was destroyed and spawned again. Now it does not spawn. This makes it the same as what happens when picking up the currently equipped gun when there's an open gun slot (the gun pickup is destroyed).