### PR TITLE
Remove set of cdogs_proto source files are genereated

### DIFF
--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -9,6 +9,4 @@ set(PROTO_SRCS "msg.pb.c" "nanopb/pb_decode.c" "nanopb/pb_encode.c" "nanopb/pb_c
 set(PROTO_HDRS "msg.pb.h" "nanopb/pb_decode.h" "nanopb/pb_encode.c" "nanopb/pb_common.c" "nanopb/pb.h")
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS}
-    PROPERTIES GENERATED TRUE)
 add_library(cdogs_proto STATIC ${PROTO_SRCS} ${PROTO_HDRS} msg.options msg.proto)


### PR DESCRIPTION
Hi,

When I was building cdogs-sdl I met an error, said 

``` cmd
c1 : fatal error C1083: Cannot open source file: 'D:\repos\thirdparty\cdogs-sdl\builds\src\proto\nanopb\pb_encode.c': N
o such file or directory [D:\repos\thirdparty\cdogs-sdl\builds\src\proto\cdogs_proto.vcxproj]
c1 : fatal error C1083: Cannot open source file: 'D:\repos\thirdparty\cdogs-sdl\builds\src\proto\nanopb\pb_common.c': N
o such file or directory [D:\repos\thirdparty\cdogs-sdl\builds\src\proto\cdogs_proto.vcxproj]
c1 : fatal error C1083: Cannot open source file: 'D:\repos\thirdparty\cdogs-sdl\builds\src\proto\msg.pb.c': No such fil
e or directory [D:\repos\thirdparty\cdogs-sdl\builds\src\proto\cdogs_proto.vcxproj]
c1 : fatal error C1083: Cannot open source file: 'D:\repos\thirdparty\cdogs-sdl\builds\src\proto\nanopb\pb_decode.c': N
o such file or directory [D:\repos\thirdparty\cdogs-sdl\builds\src\proto\cdogs_proto.vcxproj]
```

So I check the script used to build the project, which is

``` batch
if not exist "builds/" mkdir builds
cmake -B builds -S . -A Win32 -DCMAKE_TOOLCHAIN_FILE=D:/vcpkg/scripts/buildsystems/vcpkg.cmake
```

Finally find out the problem is I put everything CMake generated into `builds` direcotory, and cdogs_proto's CMakeLists.txt set all its source files are `GENERATED`, which makes final full paths are relative to `builds` directory.

https://github.com/Kitware/CMake/blob/b5b4ae17dcbc3ad813fca074478611afb1700232/Source/cmSourceFile.cxx#L123-L130

Seems cdogs_proto sources are not generated anymore, maybe set them as generated should be remove in CMakeLists.txt?

Build environment:
- Visual Studio 2019
- vcpkg