### PR TITLE
Remove duplicate creation of brass shells

### DIFF
--- a/src/cdogs/handle_game_events.c
+++ b/src/cdogs/handle_game_events.c
@@ -421,7 +421,7 @@ static void HandleGameEvent(
 		SoundPlayAtPlusDistance(
 			sd, wc->u.Normal.ReloadSound, pos, RELOAD_DISTANCE_PLUS);
 		// Brass shells
-		if (wc->u.Normal.Brass)
+		if (wc->u.Normal.Brass && wc->u.Normal.ReloadLead != 0)
 		{
 			WeaponClassAddBrass(wc, (direction_e)e.u.GunReload.Direction, pos);
 		}


### PR DESCRIPTION
Addresses #774.

Brass shells were being created in two different places, when the player shoots and when the gun is reloaded. I went ahead and removed one of them.