### PR TITLE
Security fixes for yajl

### DIFF
--- a/src/cdogs/yajl/yajl_buf.c
+++ b/src/cdogs/yajl/yajl_buf.c
@@ -45,7 +45,17 @@ void yajl_buf_ensure_available(yajl_buf buf, size_t want)
 
     need = buf->len;
 
-    while (want >= (need - buf->used)) need <<= 1;
+    if (((buf->used > want) ? buf->used : want) > (size_t)(buf->used + want)) {
+        /* We cannot allocate more memory than SIZE_MAX. */
+        abort();
+    }
+    while (want >= (need - buf->used)) {
+        if (need >= (size_t)((size_t)(-1)<<1)>>1) {
+            /* need would overflow. */
+            abort();
+        }
+        need <<= 1;
+    }
 
     if (need != buf->len) {
         buf->data = (unsigned char *) YA_REALLOC(buf->alloc, buf->data, need);

--- a/src/cdogs/yajl/yajl_encode.c
+++ b/src/cdogs/yajl/yajl_encode.c
@@ -139,8 +139,8 @@ void yajl_string_decode(yajl_buf buf, const unsigned char * str,
                     end+=3;
                     /* check if this is a surrogate */
                     if ((codepoint & 0xFC00) == 0xD800) {
-                        end++;
-                        if (str[end] == '\\' && str[end + 1] == 'u') {
+                        if (end + 2 < len && str[end + 1] == '\\' && str[end + 2] == 'u') {
+                            end++;
                             unsigned int surrogate = 0;
                             hexToDigit(&surrogate, str + end + 2);
                             codepoint =

--- a/src/cdogs/yajl/yajl_tree.c
+++ b/src/cdogs/yajl/yajl_tree.c
@@ -143,7 +143,7 @@ static yajl_val context_pop(context_t *ctx)
     ctx->stack = stack->next;
 
     v = stack->value;
-
+    free (stack->key);
     free (stack);
 
     return (v);
@@ -444,7 +444,14 @@ yajl_val yajl_tree_parse (const char *input,
              snprintf(error_buffer, error_buffer_size, "%s", internal_err_str);
              YA_FREE(&(handle->alloc), internal_err_str);
         }
+        while(ctx.stack != NULL) {
+             yajl_val v = context_pop(&ctx);
+             yajl_tree_free(v);
+        }
         yajl_free (handle);
+	//If the requested memory is not released in time, it will cause memory leakage
+	if(ctx.root)
+	     yajl_tree_free(ctx.root);
         return NULL;
     }
 


### PR DESCRIPTION
The modified copy of yajl contains some security issues that were fixed in Debian's yajl package (CVE-2017-16516, CVE-2022-24795, CVE-2023-33460).

See also:
https://security-tracker.debian.org/tracker/source-package/yajl
https://udd.debian.org/patches.cgi?src=yajl&version=2.1.0-5