### PR TITLE
Issue 848 - List of linux package managers where C-Dogs SDL is available

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -32,7 +32,7 @@ Package: <a href="https://packages.fedoraproject.org/pkgs/cdogs-sdl/cdogs-sdl">c
   <pre><code>sudo dnf install cdogs-sdl</code></pre>
   <h5>Ubuntu</h5>
   <p>
-    Package: <a href="https://packages.ubuntu.com/plucky/cdogs-sdl">cdogs-sdl</a>
+    Package: <a href="https://packages.ubuntu.com/search?keywords=cdogs-sdl&searchon=names">cdogs-sdl</a>
   </p>
   <p>Install with:</p>
   <pre><code>sudo apt install cdogs-sdl</code></pre>

--- a/downloads.html
+++ b/downloads.html
@@ -24,15 +24,15 @@ title: C-Dogs SDL Downloads
     the generic Linux binary.
   </p>
 
-  <h5>Fedora 42</h5>
+  <h5>Fedora</h5>
   <p>
-Package: <a href="https://packages.fedoraproject.org/pkgs/cdogs-sdl/cdogs-sdl/fedora-42.html">cdogs-sdl-0.7.3-14.fc42.rpm</a>
+Package: <a href="https://packages.fedoraproject.org/pkgs/cdogs-sdl/cdogs-sdl">cdogs-sdl</a>
   </p>
   <p>Install with:</p>
   <pre><code>sudo dnf install cdogs-sdl</code></pre>
-  <h5>Ubuntu 25.04 LTS</h5>
+  <h5>Ubuntu</h5>
   <p>
-    Package: <a href="https://packages.ubuntu.com/plucky/cdogs-sdl">cdogs-sdl_2.1.0.deb</a>
+    Package: <a href="https://packages.ubuntu.com/plucky/cdogs-sdl">cdogs-sdl</a>
   </p>
   <p>Install with:</p>
   <pre><code>sudo apt install cdogs-sdl</code></pre>

--- a/downloads.html
+++ b/downloads.html
@@ -50,7 +50,7 @@ Package: <a href="https://packages.fedoraproject.org/pkgs/cdogs-sdl/cdogs-sdl">c
 
   <h5>Debian</h5>
   <p>
-    Package: <a href="https://packages.debian.org/trixie/cdogs-sdl">cdogs-sdl</a>
+    Package: <a href="https://packages.debian.org/search?searchon=names&keywords=cdogs-sdl">cdogs-sdl</a>
   </p>
   <p>Install with:</p>
   <pre><code>sudo apt install cdogs-sdl</code></pre>

--- a/downloads.html
+++ b/downloads.html
@@ -45,6 +45,34 @@ Package: <a href="https://packages.fedoraproject.org/pkgs/cdogs-sdl/cdogs-sdl">c
   <pre><code>yay -S cdogs</code></pre>
   <p>Or manually from AUR:</p>
   <pre><code>git clone https://aur.archlinux.org/cdogs.git
-cd cdogs
-makepkg -si</code></pre>
-</div>
+  cd cdogs
+  makepkg -si</code></pre>
+
+  <h5>Debian</h5>
+  <p>
+    Package: <a href="https://packages.debian.org/trixie/cdogs-sdl">cdogs-sdl</a>
+  </p>
+  <p>Install with:</p>
+  <pre><code>sudo apt install cdogs-sdl</code></pre>
+
+  <h5>Alpine Linux</h5>
+  <p>
+    Package: <a href="https://pkgs.alpinelinux.org/package/edge/testing/x86_64/cdogs-sdl">cdogs-sdl</a>
+  </p>
+  <p>Install with:</p>
+  <pre><code>sudo apk add cdogs-sdl</code></pre>
+
+  <h5>Gentoo</h5>
+  <p>
+    Package: <a href="https://packages.gentoo.org/packages/games-arcade/cdogs-sdl">cdogs-sdl</a>
+  </p>
+  <p>Install with:</p>
+  <pre><code>emerge games/cdogs-sdl</code></pre>
+
+  <h5>OpenSUSE</h5>
+  <p>
+    Package: <a href="https://software.opensuse.org/package/cdogs-sdl">cdogs-sdl</a>
+  </p>
+  <p>Install with:</p>
+  <pre><code>sudo zypper install cdogs-sdl</code></pre>
+  </div>

--- a/downloads.html
+++ b/downloads.html
@@ -26,7 +26,7 @@ title: C-Dogs SDL Downloads
 
   <h5>Fedora 42</h5>
   <p>
-Package: <a href="https://packages.fedoraproject.org/pkgs/cdogs-sdl/cdogs-sdl/fedora-42.html">cdogs-sdl-2.0.0-1.fc42.x86_64.rpm</a>
+Package: <a href="https://packages.fedoraproject.org/pkgs/cdogs-sdl/cdogs-sdl/fedora-42.html">cdogs-sdl-0.7.3-14.fc42.rpm</a>
   </p>
   <p>Install with:</p>
   <pre><code>sudo dnf install cdogs-sdl</code></pre>

--- a/downloads.html
+++ b/downloads.html
@@ -32,7 +32,7 @@ Package: <a href="https://packages.fedoraproject.org/pkgs/cdogs-sdl/cdogs-sdl/fe
   <pre><code>sudo dnf install cdogs-sdl</code></pre>
   <h5>Ubuntu 25.04 LTS</h5>
   <p>
-    Package: <a href="https://packages.ubuntu.com/plucky/cdogs-sdl">cdogs-sdl_2.0.0-1_amd64.deb</a>
+    Package: <a href="https://packages.ubuntu.com/plucky/cdogs-sdl">cdogs-sdl_2.1.0.deb</a>
   </p>
   <p>Install with:</p>
   <pre><code>sudo apt install cdogs-sdl</code></pre>

--- a/downloads.html
+++ b/downloads.html
@@ -17,4 +17,34 @@ title: C-Dogs SDL Downloads
       <a href="missionpack.zip">Mission pack</a>
     </li>
   </ul>
+  <h4>Linux packages for cdogs-sdl</h4>
+  <p>
+    C-Dogs SDL is available through various Linux distribution package managers.
+    Installing through your distribution's package manager is recommended over
+    the generic Linux binary.
+  </p>
+
+  <h5>Fedora 42</h5>
+  <p>
+Package: <a href="https://packages.fedoraproject.org/pkgs/cdogs-sdl/cdogs-sdl/fedora-42.html">cdogs-sdl-2.0.0-1.fc42.x86_64.rpm</a>
+  </p>
+  <p>Install with:</p>
+  <pre><code>sudo dnf install cdogs-sdl</code></pre>
+  <h5>Ubuntu 25.04 LTS</h5>
+  <p>
+    Package: <a href="https://packages.ubuntu.com/plucky/cdogs-sdl">cdogs-sdl_2.0.0-1_amd64.deb</a>
+  </p>
+  <p>Install with:</p>
+  <pre><code>sudo apt install cdogs-sdl</code></pre>
+
+  <h5>Arch Linux (AUR)</h5>
+  <p>
+    Package: <a href="https://aur.archlinux.org/packages/cdogs">cdogs</a>
+  </p>
+  <p>Install with an AUR helper (e.g., yay):</p>
+  <pre><code>yay -S cdogs</code></pre>
+  <p>Or manually from AUR:</p>
+  <pre><code>git clone https://aur.archlinux.org/cdogs.git
+cd cdogs
+makepkg -si</code></pre>
 </div>


### PR DESCRIPTION
This PR addresses [Issue 848](https://github.com/cxong/cdogs-sdl/issues/848) in the `gh-pages` branch of cdogs-sdl repo.

I added a new section, **Linux packages for cdogs-sdl**, which lists major Linux distributions that have `cdogs-sdl` packages available as well as package manager command examples of how to install `cdogs-sdl` for each Linux distro.

URL's to each distribution's package manager index entry for `cdogs-sdl` are included, but the links are intentionally version-agnostic to avoid the problem of stale links.