### PR TITLE
fix: consistent config dir creation with trailing slash (#872)

### DIFF
--- a/src/cdogs/files.c
+++ b/src/cdogs/files.c
@@ -609,6 +609,18 @@ const char *GetHomeDirectory(void)
 char cfpath[CDOGS_PATH_MAX];
 const char *GetConfigFilePath(const char *name)
 {
+	const char *customConfigDir = getenv("CDOGS_CONFIG_DIR");
+    if (customConfigDir != NULL && strlen(customConfigDir) > 0)
+    {
+        strcpy(cfpath, customConfigDir);
+        char lastChar = cfpath[strlen(cfpath) - 1];
+        if (lastChar != '/' && lastChar != '\\') {
+            strcat(cfpath, "/");
+        }
+        strcat(cfpath, name);
+        return cfpath;
+    }
+
 	const char *xdgConfigDir = getenv("XDG_CONFIG_HOME");
 	if (xdgConfigDir != NULL)
 	{


### PR DESCRIPTION
Fixes #872.

The configuration directory logic previously appended "C-Dogs SDL" if the provided path ended with a trailing slash, causing inconsistent behavior compared to paths without a trailing slash.

This change modifies `files.c` to:
1. Check if `CDOGS_CONFIG_DIR` is set.
2. If set, use the path exactly as provided (ensuring a trailing slash for file concatenation), without appending the application name.
3. Fallback to default behavior otherwise.