### PR TITLE
UX: Reduce game music volume when pause menu shown

### DIFF
--- a/src/cdogs/music.h
+++ b/src/cdogs/music.h
@@ -57,6 +57,8 @@
 
 #include "c_array.h"
 
+#define MUSIC_REDUCTION_RATE 0.25
+
 typedef enum
 {
 	MUSIC_MENU,
@@ -78,6 +80,7 @@ typedef enum
 typedef struct
 {
 	bool isInitialised;
+	bool isReduced;
 	MusicSourceType type;
 	union {
 		Mix_Music *general;

--- a/src/cdogs/sounds.c
+++ b/src/cdogs/sounds.c
@@ -283,7 +283,7 @@ void SoundReconfigure(SoundDevice *s)
 	const int sVol = ConfigGetInt(&gConfig, "Sound.SoundVolume");
 	Mix_Volume(-1, sVol);
 	const int mVol = ConfigGetInt(&gConfig, "Sound.MusicVolume");
-	Mix_VolumeMusic(mVol);
+	Mix_VolumeMusic(s->music.isReduced ? (int)(mVol * MUSIC_REDUCTION_RATE) : mVol);
 	MusicSetPlaying(&s->music, mVol > 0);
 
 	s->isInitialised = true;

--- a/src/pause_menu.c
+++ b/src/pause_menu.c
@@ -125,6 +125,7 @@ bool PauseMenuUpdate(
 		{
 			// Unpause
 			pm->pausingDevice = INPUT_DEVICE_UNSET;
+			gSoundDevice.music.isReduced = false;
 			if (pm->ms.current->type == MENU_TYPE_RETURN)
 			{
 				// Quit
@@ -146,13 +147,16 @@ bool PauseMenuUpdate(
 		// Pause the game
 		pm->pausingDevice = firstPausingDevice;
 		SoundPlay(&gSoundDevice, StrSound("menu_error"));
+		gSoundDevice.music.isReduced = true;
 	}
 	else if (pausingDevice != INPUT_DEVICE_UNSET)
 	{
 		// Pause the game
 		pm->pausingDevice = pausingDevice;
 		SoundPlay(&gSoundDevice, StrSound("menu_back"));
+		gSoundDevice.music.isReduced = true;
 	}
+	SoundReconfigure(&gSoundDevice);
 	return false;
 }
 void PauseMenuDraw(const PauseMenu *pm)


### PR DESCRIPTION
Attempted this feature (#895) request in the most minimal way possible, utilizing helper functions that already existed rather than creating a new one. This way that audio remains muted even while configuring in the pause menu. Lmk what I can fix, I'm new to this project.