### PR TITLE
Check characters for tile-clear trigger conditions

### DIFF
--- a/src/cdogs/triggers.c
+++ b/src/cdogs/triggers.c
@@ -214,8 +214,11 @@ static bool ConditionsMet(CArray *conditions, const int ticks)
 		switch (c->Type)
 		{
 		case CONDITION_TILECLEAR:
-			conditionMet = TileIsClear(MapGetTile(&gMap, c->Pos));
+		{
+			Tile *tile = MapGetTile(&gMap, c->Pos);
+			conditionMet = tile != NULL && !TileHasCharacter(tile);
 			break;
+		}
 		}
 		if (conditionMet)
 		{


### PR DESCRIPTION
## Summary
- update CONDITION_TILECLEAR to only wait for characters to leave the tile
- keep missing tiles as unmet conditions while allowing closed doors and pickups to stop blocking the trigger

Fixes #733

## Testing
- git diff --check
- cmake -S . -B /tmp/cdogs-sdl-build -G Ninja -DCMAKE_BUILD_TYPE=Debug (stops because SDL2_mixer is not installed in this local environment)