### PR TITLE
Fix crash and rendering glitches when the resolution changes at runtime

### DIFF
--- a/src/cdogs/draw/draw_buffer.c
+++ b/src/cdogs/draw/draw_buffer.c
@@ -73,6 +73,24 @@ void DrawBufferSetFromMap(
 	DrawBuffer *buffer, const Map *map, const struct vec2 origin,
 	const int width)
 {
+	// The view size (X_TILES/Y_TILES) is derived from the current resolution,
+	// which can change (e.g. switching to fullscreen) after this buffer was
+	// allocated. DrawTiles()/DrawBufferFix() walk the tile array using the
+	// current X_TILES/Y_TILES as the pitch, so if the resolution grew since
+	// allocation they would index past the end of the array and dereference
+	// garbage. Keep the tile array sized to the current view so it always
+	// matches how it is later read.
+	const struct vec2i view = svec2i(X_TILES, Y_TILES);
+	if (view.x != buffer->OrigSize.x || view.y != buffer->OrigSize.y)
+	{
+		LOG(LM_GFX, LL_INFO,
+			"resizing DrawBuffer to match resolution: OrigSize(%dx%d) -> (%dx%d)",
+			buffer->OrigSize.x, buffer->OrigSize.y, view.x, view.y);
+		buffer->OrigSize = view;
+		CArrayTerminate(&buffer->tiles);
+		CArrayInitFillZero(&buffer->tiles, sizeof(Tile *), view.x * view.y);
+	}
+
 	buffer->Size = svec2i(width, buffer->OrigSize.y);
 
 	buffer->xTop = (int)origin.x - TILE_WIDTH * width / 2;

--- a/src/cdogs/events.c
+++ b/src/cdogs/events.c
@@ -248,6 +248,12 @@ void EventPoll(
 			!ConfigGet(&gConfig, "Graphics.Fullscreen")->u.Bool.Value;
 		GraphicsConfigSetFromConfig(&gGraphicsDevice.cachedConfig, &gConfig);
 		GraphicsInitialize(&gGraphicsDevice);
+		// The view size (X_TILES/Y_TILES) has changed, so the draw buffers and
+		// live background must be rebuilt for the new resolution before the next
+		// draw. Flag it so the active game loop rebuilds them this frame (same
+		// path used when the resolution is changed from the options menu),
+		// otherwise a stale buffer is drawn for a frame.
+		handlers->HasResolutionChanged = true;
 	}
 
 	// Auto quit on timer

--- a/src/game.c
+++ b/src/game.c
@@ -434,6 +434,18 @@ static GameLoopResult RunGameUpdate(GameLoopData *data, LoopRunner *l)
 	if (!gCampaign.IsClient && !ConfigGetBool(&gConfig, "StartServer") &&
 		paused && !gEventHandlers.HasQuit)
 	{
+		// The game is frozen so GameUpdate() (which normally handles this) is
+		// skipped, but a resolution change still needs to reset the camera and
+		// background for the new view size and reposition the pause menu.
+		// Otherwise the game view is drawn with a stale/mismatched size, e.g.
+		// toggling fullscreen with Alt+Enter while paused.
+		if (gEventHandlers.HasResolutionChanged)
+		{
+			RunGameReset(rData);
+			rData->pm.ms.size = svec2i(
+				gGraphicsDevice.cachedConfig.Res.x,
+				gGraphicsDevice.cachedConfig.Res.y);
+		}
 		return UPDATE_RESULT_DRAW;
 	}
 

--- a/src/mainmenu.c
+++ b/src/mainmenu.c
@@ -146,6 +146,17 @@ static void MainMenuReset(MainMenuData *data)
 
 	data->entry = NULL;
 }
+// Handle a resolution change (e.g. the window being resized) by resizing the
+// background draw buffer to the new view size, keeping the current map. Unlike
+// MainMenuReset() this does not regenerate a brand new random background, which
+// looked jarring when dragging the window edge (the map changed every frame).
+static void MainMenuResize(MainMenuData *data)
+{
+	DrawBufferTerminate(&data->buffer);
+	DrawBufferInit(&data->buffer, svec2i(X_TILES, Y_TILES), data->graphics);
+
+	MenuResetSize(&data->ms);
+}
 static void MainMenuTerminate(GameLoopData *data)
 {
 	MainMenuData *mData = data->Data;
@@ -249,7 +260,7 @@ static GameLoopResult MainMenuUpdate(GameLoopData *data, LoopRunner *l)
 	}
 	if (gEventHandlers.HasResolutionChanged)
 	{
-		MainMenuReset(mData);
+		MainMenuResize(mData);
 	}
 	return result;
 }


### PR DESCRIPTION
Here is a demo of the PR. Before this PR resizing and switching between windowed and fullscreen caused crashes and various rendering errors:

https://github.com/user-attachments/assets/b3e21130-8699-4732-a61e-5fc86e481e0f


## Fix crash and rendering glitches when the resolution changes at runtime

The view-size macros `X_TILES` and `Y_TILES` are derived from the current resolution (`gGraphicsDevice.cachedConfig.Res`), so their values change whenever the resolution does — e.g. toggling fullscreen with **Alt+Enter** or resizing the window. A `DrawBuffer`, however, allocates its tile array **once** (`DrawBufferInit` stores the size as `OrigSize`), and several code paths that resize the view fail to rebuild the buffer before it is next drawn. This caused a crash and a few visual glitches.

### 1. Segfault — `src/cdogs/draw/draw_buffer.c`

`DrawTiles()` and `DrawBufferFix()` walk the tile array using the current `X_TILES` as the row pitch and `Y_TILES` as the row count. When the resolution grows after a buffer was allocated, they index past the end of the smaller allocation and dereference heap garbage (seen as bogus `Tile` pointers like `0x21` / `0xff000000`), crashing in `DrawFloor()`. It was intermittent because a deferred rebuild usually caught up a frame later; the crash only occurred when a draw happened in that gap.

**Fix:** in `DrawBufferSetFromMap()`, reallocate the tile array to the current view size whenever it differs from `OrigSize`, so it always matches how it is later read. This is a self-healing safety net for every `DrawBuffer` (menu, in-game camera, editor) regardless of rebuild timing.

### 2. Menu background glitch — `src/cdogs/events.c`

The Alt+Enter fullscreen toggle reinitialised graphics but never set `HasResolutionChanged`, so the live menu background was only rebuilt a frame later (when the async `SIZE_CHANGED` event arrived). For that frame the background was drawn at the new size against the old, smaller map, showing empty/garbled edges.

**Fix:** set `HasResolutionChanged` in the toggle handler so the active game loop rebuilds the buffers and background this frame, before drawing — the same path used when the resolution is changed from the options menu.

### 3. In-game view not redrawn when toggling while paused — `src/game.c`

`RunGameUpdate()` returns early while the game is paused or the automap is open, skipping `GameUpdate()` — which is where the `HasResolutionChanged` handling lives. Toggling fullscreen while paused therefore never reset the camera/background, leaving the game view drawn at the stale size (partial frame with leftover framebuffer content).

**Fix:** handle `HasResolutionChanged` on the paused path too, resetting the camera/background and repositioning the pause menu, mirroring the existing options-menu resolution-change callback.

### 4. Menu map regenerated on every resize — `src/mainmenu.c`

On a resolution change the menu called `MainMenuReset()`, which runs `GenerateLiveBackground()` and builds a brand new random background map. While dragging the window edge this fired every frame, so the menu background map kept changing.

**Fix:** on a resolution change, resize the background draw buffer to the new view size but keep the current map (new `MainMenuResize()`), instead of regenerating the whole background.
