### PR TITLE
Cross distribution Linux bundle (works for any distro)

### DIFF
--- a/.github/workflows/build-linux.sh
+++ b/.github/workflows/build-linux.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+cd $(dirname $0)"/../.."
+
+# Data files are resolved at runtime relative to the current working directory
+# (see GetDataFilePath in src/cdogs/utils.c), so build the bundle with the data
+# dir pointing at the working directory. The launcher scripts in the packaged
+# bundle chdir into the bundle root before exec'ing, which makes the game find
+# its data next to the binary.
+cmake -S . -B build-output -DCMAKE_BUILD_TYPE=Release -DCDOGS_DATA_DIR=./
+cmake --build build-output -j"$(( $(nproc) > 1 ? $(nproc) - 1 : 1 ))"

--- a/.github/workflows/cdogs-sdl-editor.sh
+++ b/.github/workflows/cdogs-sdl-editor.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Launcher for the campaign editor in the self-contained Linux bundle. See
+# cdogs-sdl.sh for why this chdirs into the bundle root first.
+cd "$(dirname "$0")"
+exec ./cdogs-sdl-editor "$@"

--- a/.github/workflows/cdogs-sdl.sh
+++ b/.github/workflows/cdogs-sdl.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Launcher for the self-contained Linux bundle. The game resolves its data
+# files relative to the current working directory, so chdir into the bundle
+# root before starting so it can be launched from anywhere.
+cd "$(dirname "$0")"
+exec ./cdogs-sdl "$@"

--- a/.github/workflows/package-linux-bundle.sh
+++ b/.github/workflows/package-linux-bundle.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+
+cd $(dirname $0)"/../.."
+
+# The version is assembled from three parts in CMakeLists.txt
+# (set(VERSION_MAJOR "2"), etc.), so read each one and join them.
+VERSION_MAJOR=$(grep -oP '^set\(VERSION_MAJOR "\K[^"]+' CMakeLists.txt)
+VERSION_MINOR=$(grep -oP '^set\(VERSION_MINOR "\K[^"]+' CMakeLists.txt)
+VERSION_PATCH=$(grep -oP '^set\(VERSION_PATCH "\K[^"]+' CMakeLists.txt)
+VERSION="${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}"
+PACKAGE_NAME="cdogs-sdl-${VERSION}-linux-bundle"
+PACKAGE_DIR="distrib/"$PACKAGE_NAME
+
+rm -Rf $PACKAGE_DIR
+mkdir -p $PACKAGE_DIR
+
+# Game binaries
+cp build-output/src/cdogs-sdl $PACKAGE_DIR
+cp build-output/src/cdogs-sdl-editor $PACKAGE_DIR
+
+# Game data. These are all resolved relative to the working directory at
+# runtime, so they sit next to the binary and the launcher scripts chdir here.
+cp -av data $PACKAGE_DIR/data
+cp -av missions $PACKAGE_DIR/missions
+cp -av dogfights $PACKAGE_DIR/dogfights
+cp -av graphics $PACKAGE_DIR/graphics
+cp -av music $PACKAGE_DIR/music
+cp -av sounds $PACKAGE_DIR/sounds
+cp -av doc $PACKAGE_DIR/doc
+cp -av README.md $PACKAGE_DIR/README.md
+
+# Launcher scripts. The game locates its data relative to the current working
+# directory, so chdir into the bundle root before exec'ing the binary. This
+# lets the bundle be launched from anywhere (file manager, PATH, ...).
+cp -av .github/workflows/cdogs-sdl.sh $PACKAGE_DIR/cdogs-sdl.sh
+cp -av .github/workflows/cdogs-sdl-editor.sh $PACKAGE_DIR/cdogs-sdl-editor.sh
+
+# Copy all .so files these binaries were built for, to make a self contained
+# bundle.
+#
+# We must NOT bundle any part of glibc. glibc's sub-libraries (libpthread,
+# libm, libdl, librt, libresolv, ...) share internal GLIBC_PRIVATE symbols
+# with libc.so.6 and are only ABI-compatible with the exact libc.so.6 they
+# shipped with. The final binary always loads the *host's* libc.so.6 and
+# dynamic loader (their path is baked into the ELF interpreter / NEEDED and
+# can't be overridden by rpath), so bundling e.g. Debian's libpthread.so.0
+# next to a host libc.so.6 breaks with
+#   undefined symbol: __libc_pthread_init, version GLIBC_PRIVATE
+# Because we build against an older glibc than the deploy targets, letting the
+# whole glibc family resolve from the host is both correct and forward-safe.
+#
+# The exclusion list below is the glibc-provided set only; genuinely external
+# libraries with confusingly similar names (libSDL, libmikmod, ...) are still
+# bundled.
+GLIBC_EXCLUDE='/(ld-linux[^/]*|libc|libpthread|libm|libmvec|libdl|librt|libresolv|libutil|libanl|libBrokenLocale|libnss_[^/]*|libcrypt)\.so'
+mkdir -p $PACKAGE_DIR/lib
+ldd $PACKAGE_DIR/cdogs-sdl $PACKAGE_DIR/cdogs-sdl-editor \
+	| grep "=> /" | awk '{print $3}' | sort -u \
+	| grep -vE "$GLIBC_EXCLUDE" | xargs -I '{}' cp -v '{}' $PACKAGE_DIR/lib/
+
+cd $PACKAGE_DIR
+
+# Patch binaries to use local lib/ folder
+patchelf --set-rpath '$ORIGIN/lib' --force-rpath cdogs-sdl
+patchelf --set-rpath '$ORIGIN/lib' --force-rpath cdogs-sdl-editor
+
+# Patch libraries to use local lib/ folder for transitive dependencies
+patchelf --set-rpath '$ORIGIN' --force-rpath ./lib/*.so*

--- a/.github/workflows/package-linux-bundle.yml
+++ b/.github/workflows/package-linux-bundle.yml
@@ -1,0 +1,58 @@
+name: Build Linux bundle
+
+on:
+  pull_request:
+  # Reusable: can be invoked by a release workflow on merges/tags.
+  workflow_call:
+
+jobs:
+  build-linux:
+    name: Build Linux-bundle
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          # Drop broken pre-installed third-party apt repos (microsoft/azure); we don't use them.
+          sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure*
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake \
+            build-essential \
+            patchelf \
+            protobuf-compiler \
+            libsdl2-dev \
+            libsdl2-mixer-dev \
+            libgl1-mesa-dev
+
+      - name: Build
+        run: ./.github/workflows/build-linux.sh
+
+      - name: Package
+        run: ./.github/workflows/package-linux-bundle.sh
+
+      # actions/upload-artifact does not preserve the Unix executable bit, so
+      # we zip the bundle ourselves first (zip stores file permissions) and
+      # upload the single archive. The +x bit on the binaries then survives the
+      # artifact round-trip into the final release asset.
+      - name: Archive bundle (preserves executable bit)
+        id: bundle
+        run: |
+          set -euo pipefail
+          cd distrib
+          dir="$(basename cdogs-sdl-*-linux-bundle)"
+          zip -r -y -q "${dir}.zip" "$dir"
+          echo "name=${dir}.zip" >> "$GITHUB_OUTPUT"
+
+      - name: Upload cdogs-sdl-linux-bundle
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ steps.bundle.outputs.name }}
+          path: distrib/cdogs-sdl-*-linux-bundle.zip
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ Thumbs.db
 .config/
 *.blend1
 emscripten/
+# Linux bundle pipeline output (.github/workflows/build-linux.sh + package-linux-bundle.sh)
+build-output/
+distrib/


### PR DESCRIPTION
I am a developer of [OpenLieroX](https://www.openlierox.net). On OpenLieroX we produce distro agnostic bundles (zipped file contaning all dependencies) so the game can run on any Linux distribution. This PR aims to port this feature to CDogs. Here you can try out how this builds work on OpenLieroX, the package called ["Linux-bundle"](https://github.com/openlierox/openlierox/releases/tag/20260710.14)

You can try the cross-distribution package for CDogs here:
https://github.com/cxong/cdogs-sdl/actions/runs/29201070697

Note: unfortunatly it is a .zip inside a .zip, but this is only when you download it from the "actions" page. When it becomes a release on the release page, there will only be 1 layer of .zip (as it should be)