### PR TITLE
Add cross distribution Linux bundle using CPack (works on any distro)

### DIFF
--- a/.github/workflows/package-linux-bundle.yml
+++ b/.github/workflows/package-linux-bundle.yml
@@ -1,0 +1,76 @@
+name: Build Linux bundle
+
+on:
+  push:
+    branches: [ master ]
+    tags:
+    - '*'
+  pull_request:
+    branches: [ master ]
+
+env:
+  CTEST_EXT_COLOR_OUTPUT: TRUE
+  CTEST_OUTPUT_ON_FAILURE: 1
+  BUILD_TYPE: Release
+  SDL_AUDIODRIVER: dummy
+  SDL_VIDEODRIVER: dummy
+
+jobs:
+  build-linux-bundle:
+    name: Build Linux bundle
+    # Pinned, unlike the other workflows: the bundle picks up glibc from the
+    # host it runs on, so the glibc we build against decides how old a distro
+    # the bundle still works on. Following ubuntu-latest would raise that
+    # floor whenever the label moves.
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Install packages
+      run: |
+        # Drop broken pre-installed third-party apt repos (microsoft/azure); we don't use them.
+        sudo rm -f /etc/apt/sources.list.d/*microsoft* /etc/apt/sources.list.d/*azure*
+        sudo apt-get update
+        sudo apt install libgl1-mesa-dev
+        sudo apt install libsdl2-dev libsdl2-mixer-dev
+        # Bundling needs patchelf, to point the binaries at the libraries we ship
+        sudo apt install patchelf
+
+    - name: Configure CMake
+      run: cmake -S . -B build-output -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCDOGS_LINUX_BUNDLE=ON -Wno-dev
+
+    - name: Build
+      run: cmake --build build-output --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: build-output
+      run: ctest -C ${{env.BUILD_TYPE}} -VV
+
+    # CPack's ZIP generator stores the Unix permissions, so the +x bit on the
+    # binaries survives into the release asset (actions/upload-artifact does
+    # not preserve it)
+    - name: Make package
+      id: package
+      run: |
+        set -euo pipefail
+        cmake --build build-output --target package
+        echo "name=$(basename build-output/cdogs-sdl-*-linux-bundle.zip)" >> "$GITHUB_OUTPUT"
+
+    # So that pull requests also get a bundle that can be downloaded and tried out
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ steps.package.outputs.name }}
+        path: build-output/cdogs-sdl-*-linux-bundle.zip
+        if-no-files-found: error
+
+    - name: Upload to the release on tags
+      uses: softprops/action-gh-release@v1
+      if: startsWith(github.ref, 'refs/tags/')
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        files: build-output/cdogs-sdl-*-linux-bundle.zip
+        fail_on_unmatched_files: true

--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,5 @@ Thumbs.db
 .config/
 *.blend1
 emscripten/
+# Build dir used by the Linux bundle workflow (.github/workflows/package-linux-bundle.yml)
+build-output/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ option(DEBUG "Enable debug build" OFF)
 option(DEBUG_PROFILE "Enable debug profile build" OFF)
 option(USE_SHARED_ENET "Use system installed copy of enet" OFF)
 option(BUILD_EDITOR "Build cdogs-sdl-editor" ON)
+# Package a self-contained zip that also carries the shared libraries the game
+# was built against, so it runs on distros we don't build a package for.
+option(CDOGS_LINUX_BUNDLE "Package a self-contained Linux bundle" OFF)
 
 # check for crosscompiling (defined when using a toolchain file)
 if(CMAKE_CROSSCOMPILING)
@@ -139,7 +142,8 @@ endif()
 set(CMAKE_MACOSX_RPATH 1)
 
 if(NOT DEFINED CDOGS_DATA_DIR)
-	if(GCW0)
+	if(GCW0 OR CDOGS_LINUX_BUNDLE)
+		# The bundle keeps the binaries in its root, next to the data
 		set(CDOGS_DATA_DIR "./")
 	else()
 		set(CDOGS_DATA_DIR "../")
@@ -203,7 +207,12 @@ endif()
 
 # Since Debian wants games binaries in /usr/games
 if(NOT DEFINED CDOGS_BIN_DIR)
-	set(CDOGS_BIN_DIR "${INSTALL_PREFIX}/bin")
+	if(CDOGS_LINUX_BUNDLE)
+		# Run straight from the bundle root, so no launcher is needed
+		set(CDOGS_BIN_DIR "${INSTALL_PREFIX}")
+	else()
+		set(CDOGS_BIN_DIR "${INSTALL_PREFIX}/bin")
+	endif()
 endif()
 
 install(
@@ -319,6 +328,33 @@ else()
 	set(CPACK_RPM_PACKAGE_LICENSE "GPL2")
 	set(CPACK_RPM_PACKAGE_GROUP "Amusements/Games/Action/Arcade")
 	set(CPACK_RPM_PACKAGE_REQUIRES "sdl_image >= 2, sdl_mixer >= 2")
+
+	if(CDOGS_LINUX_BUNDLE)
+		# Self-contained bundle: the normal Linux install plus the shared
+		# libraries the binaries were linked against, zipped up so the
+		# executable bits survive.
+		set(CPACK_GENERATOR ZIP)
+		set(CPACK_PACKAGE_FILE_NAME "cdogs-sdl-${VERSION}-linux-bundle")
+
+		find_program(PATCHELF patchelf)
+		if(NOT PATCHELF)
+			message(FATAL_ERROR
+				"patchelf not found; it is required for CDOGS_LINUX_BUNDLE")
+		endif()
+
+		set(CDOGS_BUNDLE_EXECUTABLES
+			"${CMAKE_CURRENT_BINARY_DIR}/src/cdogs-sdl")
+		if(BUILD_EDITOR)
+			list(APPEND CDOGS_BUNDLE_EXECUTABLES
+				"${CMAKE_CURRENT_BINARY_DIR}/src/cdogs-sdl-editor")
+		endif()
+		configure_file(
+			${CMAKE_SOURCE_DIR}/build/linux/bundle/bundle_libs.cmake.in
+			${CMAKE_CURRENT_BINARY_DIR}/bundle_libs.cmake
+			@ONLY)
+		# Declared last so it runs after the binaries have been installed
+		install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/bundle_libs.cmake)
+	endif()
 
 endif()
 include(CPack)

--- a/build/linux/bundle/bundle_libs.cmake.in
+++ b/build/linux/bundle/bundle_libs.cmake.in
@@ -1,0 +1,108 @@
+# Install-time script for the self-contained Linux bundle (CDOGS_LINUX_BUNDLE).
+#
+# Copies the shared libraries the game was linked against into <prefix>/lib and
+# points the binaries at them, so the resulting archive runs on distributions
+# other than the one it was built on.
+#
+# Configured from build/linux/bundle/bundle_libs.cmake.in; run by install() and
+# therefore also by CPack when it stages the package.
+
+set(BUNDLE_EXECUTABLES "@CDOGS_BUNDLE_EXECUTABLES@")
+# CMAKE_INSTALL_PREFIX doesn't include DESTDIR, same as in the install scripts
+# CMake generates itself
+set(BUNDLE_ROOT "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}")
+set(BUNDLE_BIN_DIR "${BUNDLE_ROOT}/@CDOGS_BIN_DIR@")
+set(BUNDLE_LIB_DIR "${BUNDLE_ROOT}/lib")
+set(PATCHELF "@PATCHELF@")
+
+# We must NOT bundle any part of glibc. glibc's sub-libraries (libpthread,
+# libm, libdl, librt, libresolv, ...) share internal GLIBC_PRIVATE symbols with
+# libc.so.6 and are only ABI-compatible with the exact libc.so.6 they shipped
+# with. The final binary always loads the *host's* libc.so.6 and dynamic loader
+# (their path is baked into the ELF interpreter / NEEDED and can't be
+# overridden by rpath), so bundling e.g. Debian's libpthread.so.0 next to a
+# host libc.so.6 breaks with
+#   undefined symbol: __libc_pthread_init, version GLIBC_PRIVATE
+# Because we build against an older glibc than the deploy targets, letting the
+# whole glibc family resolve from the host is both correct and forward-safe.
+#
+# This is the glibc-provided set only; genuinely external libraries with
+# confusingly similar names (libSDL, libmikmod, ...) are still bundled.
+set(GLIBC_LIBS
+	"ld-linux.*"
+	"libc"
+	"libpthread"
+	"libm"
+	"libmvec"
+	"libdl"
+	"librt"
+	"libresolv"
+	"libutil"
+	"libanl"
+	"libBrokenLocale"
+	"libnss_.*"
+	"libcrypt"
+)
+# The pre-exclude regexes are matched against the library name as the binary
+# asks for it, the post-exclude ones against the resolved path
+foreach(LIB ${GLIBC_LIBS})
+	list(APPEND GLIBC_PRE_EXCLUDE_REGEXES "^${LIB}\\.so")
+	list(APPEND GLIBC_POST_EXCLUDE_REGEXES "/${LIB}\\.so")
+endforeach()
+
+file(GET_RUNTIME_DEPENDENCIES
+	EXECUTABLES ${BUNDLE_EXECUTABLES}
+	RESOLVED_DEPENDENCIES_VAR BUNDLE_LIBS
+	UNRESOLVED_DEPENDENCIES_VAR BUNDLE_UNRESOLVED_LIBS
+	PRE_EXCLUDE_REGEXES ${GLIBC_PRE_EXCLUDE_REGEXES}
+	POST_EXCLUDE_REGEXES ${GLIBC_POST_EXCLUDE_REGEXES}
+)
+
+# Anything left unresolved would silently fall back to whatever the host has
+# (or fail to start), so fail the package instead.
+if(BUNDLE_UNRESOLVED_LIBS)
+	message(FATAL_ERROR
+		"Could not resolve bundle dependencies: ${BUNDLE_UNRESOLVED_LIBS}")
+endif()
+
+foreach(LIB ${BUNDLE_LIBS})
+	message(STATUS "Bundling ${LIB}")
+endforeach()
+
+# Libraries are referenced by SONAME (libfoo.so.0), which is usually a symlink
+# to the real file (libfoo.so.0.1.2). Copy the real file under the name the
+# binaries ask for, rather than copying the symlink chain: not every tool used
+# to unpack the zip restores symlinks.
+foreach(LIB ${BUNDLE_LIBS})
+	get_filename_component(LIB_NAME "${LIB}" NAME)
+	get_filename_component(LIB_REAL "${LIB}" REALPATH)
+	# TYPE PROGRAM rather than SHARED_LIBRARY only because RENAME is not
+	# allowed for the latter; both end up as 0755, as the originals are
+	file(INSTALL
+		DESTINATION "${BUNDLE_LIB_DIR}"
+		TYPE PROGRAM
+		RENAME "${LIB_NAME}"
+		FILES "${LIB_REAL}"
+	)
+endforeach()
+
+# Point the binaries at the bundled libraries. The binaries are installed with
+# install(PROGRAMS ...), i.e. copied verbatim, so CMake's own INSTALL_RPATH
+# handling doesn't apply and we patch them here instead. The libraries need an
+# rpath of their own as well: DT_RUNPATH (what the linker emits these days) is
+# only used for a binary's direct dependencies, not for the dependencies of
+# those dependencies, and a distro-provided library may carry a RUNPATH
+# pointing back into the host's library directory.
+file(GLOB BUNDLED_LIBS "${BUNDLE_LIB_DIR}/*.so*")
+foreach(LIB ${BUNDLED_LIBS})
+	execute_process(
+		COMMAND "${PATCHELF}" --set-rpath "$ORIGIN" --force-rpath "${LIB}"
+		COMMAND_ERROR_IS_FATAL ANY)
+endforeach()
+foreach(EXE ${BUNDLE_EXECUTABLES})
+	get_filename_component(EXE_NAME "${EXE}" NAME)
+	execute_process(
+		COMMAND "${PATCHELF}" --set-rpath "$ORIGIN/lib" --force-rpath
+			"${BUNDLE_BIN_DIR}/${EXE_NAME}"
+		COMMAND_ERROR_IS_FATAL ANY)
+endforeach()


### PR DESCRIPTION
Package the Linux build, its data and the shared libraries it was built against into a zip, so it can be run on distributions we don't build a package for.

This is done through CPack, behind a new CDOGS_LINUX_BUNDLE option; the default Linux packaging (tar.gz) is unchanged. The install-time script build/linux/bundle/bundle_libs.cmake.in collects the runtime dependencies and points the binaries at them; glibc is deliberately left to the host.

Since the game resolves its data files relative to the working directory, the bundle is started through launcher scripts that chdir first.

### How to test it from Github
The builds are triggered automatically when PRs are made

You can try the output from this PR built on github here: 
NOTE: when download it from github actions, there is a zip inside a zip, which will not be the case when the file is downloaded as a release (then it will also be 1 level of zip as it should)
https://github.com/cxong/cdogs-sdl/actions/runs/30720990870


### How to test it locally
build + package
```
cmake -S . -B build-output -DCMAKE_BUILD_TYPE=Release -DCDOGS_LINUX_BUNDLE=ON
cmake --build build-output --target package
```

unpack + run
```
unzip -q build-output/cdogs-sdl-2.4.0-linux-bundle.zip -d /tmp/cdogs-test
cd /tmp/cdogs-test/cdogs-sdl-2.4.0-linux-bundle && ./cdogs-sdl
```

This PR is a rework of the previous PR: https://github.com/cxong/cdogs-sdl/pull/904
